### PR TITLE
fix(행사): daily-shuttle date가 원치않는 날짜로 고정되는 문제

### DIFF
--- a/src/types/v2/event.type.ts
+++ b/src/types/v2/event.type.ts
@@ -49,7 +49,7 @@ export const CreateEventRequest = z.object({
   imageUrl: z.string().url(),
   regionId: z.number().int(),
   regionHubId: z.number().int(),
-  dailyEvents: z.object({}).array(),
+  dailyEvents: z.object({ date: z.date() }).array(),
   type: z.enum(['CONCERT', 'FESTIVAL']),
   artistIds: z.number().int().array(),
 });


### PR DESCRIPTION
## 개요
- event 생성에서 사용되는 event의 타입은 `CreateEventRequest`와 `CreateEventFormSchema (useform-formValue 관련)`를 씁니다.

거의 유사한 두개의 타입인데요 여기에 dailyEvents에서 누락된 부분이 존재하여 발생하는 문제였습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).