### PR TITLE
feat(행사): 거점지 시간 순서 정합성 체크 추가 및 버그 수정

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/(home)/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/(home)/page.tsx
@@ -100,12 +100,12 @@ const Page = ({ params: { eventId, dailyEventId, shuttleRouteId } }: Props) => {
           <header className="flex flex-row justify-between">
             <h3 className="text-[24px] font-500">거점지 - 목적지행</h3>
           </header>
-          <BaseTable table={fromHubTable} />
+          <BaseTable table={toHubTable} />
 
           <header className="flex flex-row justify-between">
             <h3 className="text-[24px] font-500">거점지 - 귀가행</h3>
           </header>
-          <BaseTable table={toHubTable} />
+          <BaseTable table={fromHubTable} />
 
           <Buses
             eventId={eventId}

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/conform.util.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/conform.util.ts
@@ -1,0 +1,87 @@
+import { CreateShuttleRouteRequest } from '@/types/v2/shuttleRoute.type';
+import { formatDate } from '@/utils/date.util';
+import { CreateShuttleRouteForm } from './form.type';
+
+export const conform = (
+  data: CreateShuttleRouteForm,
+): CreateShuttleRouteRequest => {
+  const validateSequenceOrder = (
+    hubs: CreateShuttleRouteRequest['shuttleRouteHubs'],
+  ) => {
+    const sortedByArrivalTime = [...hubs].sort(
+      (a, b) =>
+        new Date(a.arrivalTime).getTime() - new Date(b.arrivalTime).getTime(),
+    );
+    const isSequenceValid = hubs.every(
+      (hub, index) => hub.sequence === sortedByArrivalTime[index].sequence,
+    );
+    if (!isSequenceValid) {
+      throw new Error('arrivalTime is not validated');
+    }
+    return hubs;
+  };
+
+  const validateFromToOrder = (
+    froms: CreateShuttleRouteRequest['shuttleRouteHubs'],
+    tos: CreateShuttleRouteRequest['shuttleRouteHubs'],
+  ) => {
+    const latestFromTime = Math.max(
+      ...froms.map((hub) => new Date(hub.arrivalTime).getTime()),
+    );
+
+    const earliestToTime = Math.min(
+      ...tos.map((hub) => new Date(hub.arrivalTime).getTime()),
+    );
+
+    if (latestFromTime >= earliestToTime) {
+      throw new Error('arrivalTime is not validated');
+    }
+  };
+
+  const froms: CreateShuttleRouteRequest['shuttleRouteHubs'] =
+    data.shuttleRouteHubsFromDestination
+      .filter(
+        (dest): dest is { regionHubId: number; arrivalTime: Date } =>
+          dest.regionHubId !== null,
+      )
+      .map((v, idx) => ({
+        ...v,
+        sequence: idx + 1,
+        type: 'FROM_DESTINATION',
+        arrivalTime: formatDate(v.arrivalTime, 'datetime'),
+      })) satisfies CreateShuttleRouteRequest['shuttleRouteHubs'];
+
+  const tos: CreateShuttleRouteRequest['shuttleRouteHubs'] =
+    data.shuttleRouteHubsToDestination
+      .filter(
+        (dest): dest is { regionHubId: number; arrivalTime: Date } =>
+          dest.regionHubId !== null,
+      )
+      .map((v, idx) => ({
+        ...v,
+        sequence: idx + 1,
+        type: 'TO_DESTINATION',
+        arrivalTime: formatDate(v.arrivalTime, 'datetime'),
+      })) satisfies CreateShuttleRouteRequest['shuttleRouteHubs'];
+
+  const {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we don't need to use these
+    shuttleRouteHubsToDestination,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we don't need to use these
+    shuttleRouteHubsFromDestination,
+    ...rest
+  } = data;
+
+  validateSequenceOrder(tos);
+  validateSequenceOrder(froms);
+  validateFromToOrder(tos, froms);
+  const x = {
+    ...rest,
+    shuttleRouteHubs: froms.concat(tos),
+    reservationDeadline: formatDate(data.reservationDeadline, 'datetime'),
+    earlybirdDeadline: data.earlybirdDeadline
+      ? formatDate(data.earlybirdDeadline, 'datetime')
+      : null,
+  } satisfies CreateShuttleRouteRequest;
+  return x;
+};

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/form.type.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/form.type.ts
@@ -1,8 +1,5 @@
 import { z } from 'zod';
 
-import { CreateShuttleRouteRequest } from '@/types/v2/shuttleRoute.type';
-import { formatDate } from '@/utils/date.util';
-
 export const CreateShuttleRouteFormSchema = z.object({
   name: z.string(),
   reservationDeadline: z.coerce.date(),
@@ -36,51 +33,3 @@ export const CreateShuttleRouteFormSchema = z.object({
 export type CreateShuttleRouteForm = z.infer<
   typeof CreateShuttleRouteFormSchema
 >;
-
-export const conform = (
-  data: CreateShuttleRouteForm,
-): CreateShuttleRouteRequest => {
-  const froms: CreateShuttleRouteRequest['shuttleRouteHubs'] =
-    data.shuttleRouteHubsFromDestination
-      .filter(
-        (dest): dest is { regionHubId: number; arrivalTime: Date } =>
-          dest.regionHubId !== null,
-      )
-      .map((v, idx) => ({
-        ...v,
-        sequence: idx + 1,
-        type: 'FROM_DESTINATION',
-        arrivalTime: formatDate(v.arrivalTime, 'datetime'),
-      })) satisfies CreateShuttleRouteRequest['shuttleRouteHubs'];
-
-  const tos: CreateShuttleRouteRequest['shuttleRouteHubs'] =
-    data.shuttleRouteHubsToDestination
-      .filter(
-        (dest): dest is { regionHubId: number; arrivalTime: Date } =>
-          dest.regionHubId !== null,
-      )
-      .map((v, idx) => ({
-        ...v,
-        sequence: idx + 1,
-        type: 'TO_DESTINATION',
-        arrivalTime: formatDate(v.arrivalTime, 'datetime'),
-      })) satisfies CreateShuttleRouteRequest['shuttleRouteHubs'];
-
-  const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we don't need to use these
-    shuttleRouteHubsToDestination,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we don't need to use these
-    shuttleRouteHubsFromDestination,
-    ...rest
-  } = data;
-
-  const x = {
-    ...rest,
-    shuttleRouteHubs: froms.concat(tos),
-    reservationDeadline: formatDate(data.reservationDeadline, 'datetime'),
-    earlybirdDeadline: data.earlybirdDeadline
-      ? formatDate(data.earlybirdDeadline, 'datetime')
-      : null,
-  } satisfies CreateShuttleRouteRequest;
-  return x;
-};

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
-import { conform, type CreateShuttleRouteForm } from './form.type';
+import { type CreateShuttleRouteForm } from './form.type';
 import { postRoute } from '@/services/v2/shuttleRoute.services';
 import { useRouter } from 'next/navigation';
 import Input from '@/components/input/Input';
@@ -15,6 +15,7 @@ import { useMemo } from 'react';
 import DateInput from '@/components/input/DateInput';
 import DateTimeInput from '@/components/input/DateTimeInput';
 import { twMerge } from 'tailwind-merge';
+import { conform } from './conform.util';
 
 interface Props {
   params: { eventId: string; dailyEventId: string };
@@ -136,7 +137,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
   const {
     fields: toDestHubFields,
-    append: appendToDestHub,
+    prepend: prependToDestHub,
     remove: removeToDestHub,
     // update: updateHub,
     swap: swapToDestHub,
@@ -152,8 +153,13 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
       alert('등록에 성공했습니다.');
       router.push(`/events/${eventId}/dates/${dailyEventId}`);
     } catch (error) {
-      alert('오류가 발생했습니다.');
       console.error(error);
+      if (
+        error instanceof Error &&
+        error.message === 'arrivalTime is not validated'
+      )
+        alert('거점지들의 시간순서가 올바르지 않습니다. 확인해주세요.');
+      else alert('오류가 발생했습니다.');
     }
   };
 
@@ -334,7 +340,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
         <button
           type="button"
           onClick={() =>
-            appendToDestHub({
+            prependToDestHub({
               regionHubId: 0,
               arrivalTime: defaultDate,
             })

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -401,7 +401,9 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                   <button
                     type="button"
                     onClick={() => index > 0 && swapToDestHub(index, index - 1)}
-                    disabled={index === 0}
+                    disabled={
+                      index === 0 || index === toDestHubFields.length - 1
+                    }
                     className="text-gray-500 hover:text-gray-700 disabled:opacity-30"
                   >
                     위로
@@ -412,7 +414,10 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                       index < toDestHubFields.length - 1 &&
                       swapToDestHub(index, index + 1)
                     }
-                    disabled={index === toDestHubFields.length - 1}
+                    disabled={
+                      index === toDestHubFields.length - 1 ||
+                      index === toDestHubFields.length - 2
+                    }
                     className="text-gray-500 hover:text-gray-700 disabled:opacity-30"
                   >
                     아래로
@@ -420,7 +425,8 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                   <button
                     type="button"
                     onClick={() => removeToDestHub(index)}
-                    className="text-red-500"
+                    className="text-red-500 disabled:opacity-30"
+                    disabled={index === toDestHubFields.length - 1}
                   >
                     삭제
                   </button>
@@ -503,7 +509,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                     onClick={() =>
                       index > 0 && swapFromDestHub(index, index - 1)
                     }
-                    disabled={index === 0}
+                    disabled={index === 0 || index === 1}
                     className="text-gray-500 hover:text-gray-700 disabled:opacity-30"
                   >
                     위로
@@ -514,7 +520,9 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                       index < fromDestHubFields.length - 1 &&
                       swapFromDestHub(index, index + 1)
                     }
-                    disabled={index === fromDestHubFields.length - 1}
+                    disabled={
+                      index === fromDestHubFields.length - 1 || index === 0
+                    }
                     className="text-gray-500 hover:text-gray-700 disabled:opacity-30"
                   >
                     아래로
@@ -522,7 +530,8 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                   <button
                     type="button"
                     onClick={() => removeFromDestHub(index)}
-                    className="text-red-500"
+                    className="text-red-500 disabled:opacity-30"
+                    disabled={index === 0}
                   >
                     삭제
                   </button>

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -242,7 +242,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
           <div className="flex flex-col items-start gap-8">
             <label className="break-keep">
-              목적지행 {formated(watchRegularPrice.toDestination)}원
+              목적지행 {formatted(watchRegularPrice.toDestination)}원
             </label>
             <Input
               type="number"
@@ -254,7 +254,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
           <div className="flex flex-col items-start gap-8">
             <label className="break-keep">
-              귀가행 {formated(watchRegularPrice.fromDestination)}원
+              귀가행 {formatted(watchRegularPrice.fromDestination)}원
             </label>
             <Input
               type="number"
@@ -266,7 +266,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
           <div className="flex flex-col items-start gap-8">
             <label className="break-keep">
-              왕복 {formated(watchRegularPrice.roundTrip)}원
+              왕복 {formatted(watchRegularPrice.roundTrip)}원
             </label>
             <Input
               type="number"
@@ -280,7 +280,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
           <div className="flex flex-col items-start gap-8">
             <label className="break-keep">
-              목적지행 {formated(watchEarlybirdPrice.toDestination)}원
+              목적지행 {formatted(watchEarlybirdPrice.toDestination)}원
               {discountPercent(
                 watchRegularPrice.toDestination,
                 watchEarlybirdPrice.toDestination,
@@ -297,7 +297,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
           <div className="flex flex-col items-start gap-8">
             <label className="break-keep">
-              귀가행 {formated(watchEarlybirdPrice.fromDestination)}원
+              귀가행 {formatted(watchEarlybirdPrice.fromDestination)}원
               {discountPercent(
                 watchRegularPrice.fromDestination,
                 watchEarlybirdPrice.fromDestination,
@@ -314,7 +314,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
           <div className="flex flex-col items-start gap-8">
             <label className="break-keep">
-              왕복 {formated(watchEarlybirdPrice.roundTrip)}원
+              왕복 {formatted(watchEarlybirdPrice.roundTrip)}원
               {discountPercent(
                 watchRegularPrice.roundTrip,
                 watchEarlybirdPrice.roundTrip,
@@ -540,12 +540,12 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
   );
 };
 
-const formated = (n: number) => {
+const formatted = (n: number) => {
   return n.toLocaleString('ko-KR');
 };
 
-const discountPercent = (price: number, priceAfterDiscound: number) => {
-  const amount = ((price - priceAfterDiscound) / price) * 100;
+const discountPercent = (price: number, priceAfterDiscount: number) => {
+  const amount = ((price - priceAfterDiscount) / price) * 100;
   if (amount < 0) return '(오류: 더 비싼 가격)';
   return '(-' + amount.toFixed(2) + '%)';
 };


### PR DESCRIPTION
## 개요

- [버그수정] 행사 - dailyshuttle - 노선 : 목적지행과 귀가행의 거점지 정보가 반대로 표시되던 버그를 수정했습니다.
- [오타수정] 함수명 오타 수정 : fomated -> formatted, discound -> discount
- [기능추가] 행사 - dailyshuttle - 노선 추가 : 목적지, 출발지 순서 고정 및 삭제 비활성화처리
- [기능추가] arrival time validate alert 추가 : 앞으로 거점지들의 시간순서가 올바르지 않으면 등록시 경고알림창이 뜨고 등록이 실패합니다.
  - 거점지들은 앞 -> 뒤 순서로 시간순서가 일치해야합니다.
  - 또한 목적지행보다 귀가행 시간이 이른경우 등록이 실패합니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).