### PR TITLE
feat(행사): 거점지가 비어있을때 새 거점 만들기로 새탭이동 추가

### DIFF
--- a/src/components/input/HubInput.tsx
+++ b/src/components/input/HubInput.tsx
@@ -22,6 +22,7 @@ interface Props {
 
 import { ChevronDown } from 'lucide-react';
 import RegionInput from './RegionInput';
+import Link from 'next/link';
 
 const validRegionID = (regionId: number | undefined): regionId is number =>
   typeof regionId === 'number' && !Number.isNaN(regionId);
@@ -100,6 +101,16 @@ const RegionHubInput = ({ regionId, value, setValue }: Props) => {
               {hub.name}
             </ComboboxOption>
           ))}
+          {data?.length === 0 && !isLoading && validRegionID(regionId) && (
+            <Link
+              href="/hubs/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block p-8 text-blue-500 hover:bg-blue-50"
+            >
+              + 새로운 거점 만들기
+            </Link>
+          )}
         </ComboboxOptions>
       </div>
     </Combobox>


### PR DESCRIPTION
# 개요
거점지의 위치를 선택해야하는 지점에서 거점지가 존재하지 않을때 '새로운 거점 만들기'라는 항목이 표시되고, 클릭하면 새 탭으로 거점지 추가하기 페이지가 열립니다.

### 행사 - 행사 추가하기 : 거점지가 존재하는 경우, 존재하지 않는 경우
<img width="625" alt="Screenshot 2025-01-21 at 4 34 30 PM" src="https://github.com/user-attachments/assets/373eee14-bf05-4038-949b-648532bef3c2" />

<img width="621" alt="Screenshot 2025-01-21 at 4 34 24 PM" src="https://github.com/user-attachments/assets/b764fa00-49a2-488e-8922-2333042a2f3f" />

### 행사 - 데일리 셔틀 - 노선 - 노선 추가하기 : 거점지가 존재하는 경우, 존재하지 않는 경우
<img width="656" alt="Screenshot 2025-01-21 at 4 35 49 PM" src="https://github.com/user-attachments/assets/3b6bc2b0-1a93-4212-8825-33f62bb019d2" />
<img width="651" alt="Screenshot 2025-01-21 at 4 35 39 PM" src="https://github.com/user-attachments/assets/21869cad-eb68-4b50-a24c-3ab988a4d09d" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).