### PR TITLE
feat: 노선 생성 시 경유지 미러링 기능 추가

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
@@ -116,7 +116,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     handleSubmit,
     formState: { errors },
   } = useForm<UpdateShuttleRouteRequestFormData>({
-    // resolver: zodResolver(CreateShuttleRouteRequestSchema),
     defaultValues,
   });
 
@@ -124,7 +123,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     fields: fromDestHubFields,
     append: appendFromDestHub,
     remove: removeFromDestHub,
-    // update: updateHub,
     swap: swapFromDestHub,
   } = useFieldArray({
     control,
@@ -135,7 +133,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     fields: toDestHubFields,
     prepend: prependToDestHub,
     remove: removeToDestHub,
-    // update: updateHub,
     swap: swapToDestHub,
   } = useFieldArray({
     control,
@@ -260,14 +257,14 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                       name={`shuttleRouteHubsToDestination.${index}` as const}
                       render={({ field: { onChange, value } }) => (
                         <RegionHubInputSelfContained
-                          value={value.regionHubId}
-                          setValue={(newValue) =>
-                            onChange({
-                              ...value,
-                              regionHubId: newValue,
-                            })
+                          regionId={value.regionId ?? null}
+                          setRegionId={(regionId) =>
+                            onChange({ ...value, regionId })
                           }
-                          initialRegionId={value.regionId}
+                          regionHubId={value.regionHubId ?? null}
+                          setRegionHubId={(regionHubId) =>
+                            onChange({ ...value, regionHubId })
+                          }
                         />
                       )}
                     />
@@ -364,14 +361,14 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                       name={`shuttleRouteHubsFromDestination.${index}` as const}
                       render={({ field: { onChange, value } }) => (
                         <RegionHubInputSelfContained
-                          value={value.regionHubId}
-                          setValue={(newValue) =>
-                            onChange({
-                              ...value,
-                              regionHubId: newValue,
-                            })
+                          regionId={value.regionId ?? null}
+                          setRegionId={(regionId) =>
+                            onChange({ ...value, regionId })
                           }
-                          initialRegionId={value.regionId}
+                          regionHubId={value.regionHubId ?? null}
+                          setRegionHubId={(regionHubId) =>
+                            onChange({ ...value, regionHubId })
+                          }
                         />
                       )}
                     />

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/conform.util.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/conform.util.ts
@@ -40,26 +40,36 @@ export const conform = (
   const froms: CreateShuttleRouteRequest['shuttleRouteHubs'] =
     data.shuttleRouteHubsFromDestination
       .filter(
-        (dest): dest is { regionHubId: number; arrivalTime: string } =>
-          dest.regionHubId !== null,
+        (
+          dest,
+        ): dest is {
+          regionId: number;
+          regionHubId: number;
+          arrivalTime: string;
+        } => dest.regionHubId !== null,
       )
       .map((v, idx) => ({
-        ...v,
         sequence: idx + 1,
         type: 'FROM_DESTINATION',
+        regionHubId: v.regionHubId,
         arrivalTime: v.arrivalTime,
       })) satisfies CreateShuttleRouteRequest['shuttleRouteHubs'];
 
   const tos: CreateShuttleRouteRequest['shuttleRouteHubs'] =
     data.shuttleRouteHubsToDestination
       .filter(
-        (dest): dest is { regionHubId: number; arrivalTime: string } =>
-          dest.regionHubId !== null,
+        (
+          dest,
+        ): dest is {
+          regionId: number;
+          regionHubId: number;
+          arrivalTime: string;
+        } => dest.regionHubId !== null,
       )
       .map((v, idx) => ({
-        ...v,
         sequence: idx + 1,
         type: 'TO_DESTINATION',
+        regionHubId: v.regionHubId,
         arrivalTime: v.arrivalTime,
       })) satisfies CreateShuttleRouteRequest['shuttleRouteHubs'];
 

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/form.type.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/form.type.ts
@@ -18,12 +18,14 @@ export const CreateShuttleRouteFormSchema = z.object({
   maxPassengerCount: z.number(),
   shuttleRouteHubsToDestination: z.array(
     z.object({
+      regionId: z.number().nullable(),
       regionHubId: z.number().nullable(),
       arrivalTime: z.string(),
     }),
   ),
   shuttleRouteHubsFromDestination: z.array(
     z.object({
+      regionId: z.number().nullable(),
       regionHubId: z.number().nullable(),
       arrivalTime: z.string(),
     }),

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -58,20 +58,24 @@ const Page = ({ params }: Props) => {
       },
       shuttleRouteHubsFromDestination: [
         {
+          regionId: null,
           regionHubId: null,
           arrivalTime: defaultDate ?? '',
         },
         {
+          regionId: null,
           regionHubId: null,
           arrivalTime: defaultDate ?? '',
         },
       ],
       shuttleRouteHubsToDestination: [
         {
+          regionId: null,
           regionHubId: null,
           arrivalTime: defaultDate ?? '',
         },
         {
+          regionId: null,
           regionHubId: null,
           arrivalTime: defaultDate ?? '',
         },
@@ -110,8 +114,9 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     watch,
     handleSubmit,
     formState: { errors },
+    getValues,
+    setValue,
   } = useForm<CreateShuttleRouteForm>({
-    // resolver: zodResolver(CreateShuttleRouteRequestSchema),
     defaultValues,
   });
 
@@ -123,7 +128,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     fields: fromDestHubFields,
     append: appendFromDestHub,
     remove: removeFromDestHub,
-    // update: updateHub,
     swap: swapFromDestHub,
   } = useFieldArray({
     control,
@@ -134,7 +138,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     fields: toDestHubFields,
     prepend: prependToDestHub,
     remove: removeToDestHub,
-    // update: updateHub,
     swap: swapToDestHub,
   } = useFieldArray({
     control,
@@ -174,6 +177,19 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
       )
         alert('거점지들의 시간순서가 올바르지 않습니다. 확인해주세요.');
     }
+  };
+
+  const handleMirrorHub = () => {
+    const isConfirmed = confirm(
+      '목적지행의 경유지들을 귀가행에 미러링하시겠습니까?\n기존에 귀가행에 있던 경유지들은 모두 삭제됩니다.',
+    );
+    if (!isConfirmed) {
+      return;
+    }
+    const reversedToDestinationHubs = getValues(
+      'shuttleRouteHubsToDestination',
+    ).toReversed();
+    setValue('shuttleRouteHubsFromDestination', reversedToDestinationHubs);
   };
 
   return (
@@ -361,7 +377,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
             </div>
           </article>
         </FormContainer.section>
-
         <FormContainer.section>
           <FormContainer.label>경유지</FormContainer.label>
           <Callout className="text-14">
@@ -381,7 +396,8 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                 type="button"
                 onClick={() =>
                   prependToDestHub({
-                    regionHubId: 0,
+                    regionId: null,
+                    regionHubId: null,
                     arrivalTime: defaultDate,
                   })
                 }
@@ -403,13 +419,17 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                       <label className="text-16 font-500">거점지</label>
                       <Controller
                         control={control}
-                        name={
-                          `shuttleRouteHubsToDestination.${index}.regionHubId` as const
-                        }
+                        name={`shuttleRouteHubsToDestination.${index}` as const}
                         render={({ field: { onChange, value } }) => (
                           <RegionHubInputSelfContained
-                            value={value}
-                            setValue={onChange}
+                            regionId={value.regionId}
+                            setRegionId={(regionId) =>
+                              onChange({ ...value, regionId })
+                            }
+                            regionHubId={value.regionHubId}
+                            setRegionHubId={(regionHubId) =>
+                              onChange({ ...value, regionHubId })
+                            }
                           />
                         )}
                       />
@@ -473,19 +493,27 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
             </ul>
           </section>
           <section>
-            <Heading.h5 backgroundColor="yellow">
+            <Heading.h5 backgroundColor="yellow" className="flex">
               귀가행
               <button
                 type="button"
                 onClick={() =>
                   appendFromDestHub({
-                    regionHubId: 0,
+                    regionId: null,
+                    regionHubId: null,
                     arrivalTime: defaultDate,
                   })
                 }
                 className="ml-8 text-14 text-blue-500"
               >
                 추가
+              </button>
+              <button
+                type="button"
+                onClick={handleMirrorHub}
+                className="ml-auto block text-14 text-blue-500 underline underline-offset-2"
+              >
+                목적지행을 미러링하기
               </button>
             </Heading.h5>
             <ul className="flex flex-col gap-8">
@@ -502,12 +530,18 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                       <Controller
                         control={control}
                         name={
-                          `shuttleRouteHubsFromDestination.${index}.regionHubId` as const
+                          `shuttleRouteHubsFromDestination.${index}` as const
                         }
                         render={({ field: { onChange, value } }) => (
                           <RegionHubInputSelfContained
-                            value={value}
-                            setValue={onChange}
+                            regionId={value.regionId}
+                            setRegionId={(regionId) =>
+                              onChange({ ...value, regionId })
+                            }
+                            regionHubId={value.regionHubId}
+                            setRegionHubId={(regionHubId) =>
+                              onChange({ ...value, regionHubId })
+                            }
                           />
                         )}
                       />

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -181,7 +181,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
   const handleMirrorHub = () => {
     const isConfirmed = confirm(
-      '목적지행의 경유지들을 귀가행에 미러링하시겠습니까?\n기존에 귀가행에 있던 경유지들은 모두 삭제됩니다.',
+      '목적지행의 경유지들을 귀가행에 미러링하시겠습니까?\n\n주의: 기존에 귀가행에 있던 경유지들은 모두 삭제됩니다.\n미러링을 진행한 이후 시간 순서를 확인해주세요.',
     );
     if (!isConfirmed) {
       return;
@@ -378,7 +378,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
           </article>
         </FormContainer.section>
         <FormContainer.section>
-          <FormContainer.label>경유지</FormContainer.label>
+          <FormContainer.label required>경유지</FormContainer.label>
           <Callout className="text-14">
             파란색으로 표시된 경유지는 행사 장소 근처 경유지에 해당합니다. (ex.
             인스파이어 아레나)

--- a/src/components/input/HubInput.tsx
+++ b/src/components/input/HubInput.tsx
@@ -21,9 +21,6 @@ interface Props {
   setValue: (value: number | null) => void;
 }
 
-const validRegionID = (regionId: number | undefined): regionId is number =>
-  typeof regionId === 'number' && !Number.isNaN(regionId);
-
 const RegionHubInput = ({ regionId, value, setValue }: Props) => {
   const [query, setQuery] = useState('');
 
@@ -82,6 +79,7 @@ const RegionHubInput = ({ regionId, value, setValue }: Props) => {
           defaultValue={null}
           displayValue={(hub: null | RegionHub) => hub?.name ?? ''}
           onChange={(event) => setQuery(event.target.value)}
+          autoComplete="off"
         />
 
         <ComboboxOptions
@@ -116,21 +114,27 @@ const RegionHubInput = ({ regionId, value, setValue }: Props) => {
 export default RegionHubInput;
 
 export const RegionHubInputSelfContained = ({
-  value,
-  setValue,
-  initialRegionId,
-}: Omit<Props, 'regionId'> & { initialRegionId?: number }) => {
-  const [regionId, setRegionId] = useState<number | null>(
-    initialRegionId ?? null,
-  );
+  regionId,
+  setRegionId,
+  regionHubId,
+  setRegionHubId,
+}: {
+  regionId: number | null;
+  setRegionId: (value: number | null) => void;
+  regionHubId: number | null;
+  setRegionHubId: (value: number | null) => void;
+}) => {
   return (
     <div className="flex flex-col gap-4">
       <RegionInput value={regionId} setValue={setRegionId} />
       <RegionHubInput
         regionId={regionId ?? undefined}
-        value={value}
-        setValue={setValue}
+        value={regionHubId}
+        setValue={setRegionHubId}
       />
     </div>
   );
 };
+
+const validRegionID = (regionId: number | undefined): regionId is number =>
+  typeof regionId === 'number' && !Number.isNaN(regionId);

--- a/src/components/input/RegionInput.tsx
+++ b/src/components/input/RegionInput.tsx
@@ -66,7 +66,7 @@ const RegionInput = ({ value, setValue }: Props) => {
   }, [selectedBigRegion, selectedSmallRegion]);
 
   return (
-    <div className="flex flex-col justify-start items-start w-full">
+    <div className="flex w-full flex-col items-start justify-start">
       <Combobox
         immediate
         value={selectedBigRegion}
@@ -86,29 +86,30 @@ const RegionInput = ({ value, setValue }: Props) => {
           setQueryBig('');
         }}
       >
-        <div className="relative group size-full">
+        <div className="group relative size-full">
           <ComboboxInput
-            className="p-8 
-           border border-grey-200 rounded-t-lg size-full
+            className="size-full 
+           rounded-t-lg border border-grey-200 p-8
            focus:outline-blue-400"
             aria-label="Assignee"
             placeholder={'도/광역시 선택'}
             defaultValue={null}
             displayValue={(province) => (province === null ? '' : province)}
             onChange={(event) => setQueryBig(event.target.value)}
+            autoComplete="off"
           />
           <ComboboxButton className="absolute right-4 top-1/2 -translate-y-1/2 text-grey-400 group-focus:text-blue-500">
             <ChevronDown />
           </ComboboxButton>
           <ComboboxOptions
             anchor="bottom"
-            className="w-[var(--input-width)] shadow-md bg-white rounded-lg empty:invisible mt-4"
+            className="mt-4 w-[var(--input-width)] rounded-lg bg-white shadow-md empty:invisible"
           >
             {filteredBigRegions.map((province) => (
               <ComboboxOption
                 key={province}
                 value={province}
-                className="data-[focus]:bg-blue-100 p-8"
+                className="p-8 data-[focus]:bg-blue-100"
               >
                 {province}
               </ComboboxOption>
@@ -125,29 +126,30 @@ const RegionInput = ({ value, setValue }: Props) => {
         }}
         onClose={() => setQuerySmall('')}
       >
-        <div className="relative group size-full">
+        <div className="group relative size-full">
           <ComboboxButton className="absolute right-4 top-1/2 -translate-y-1/2 text-grey-400 group-focus:text-blue-500">
             <ChevronDown />
           </ComboboxButton>
           <ComboboxInput
-            className="p-8 focus:outline-blue-400
-            border border-grey-200 rounded-b-lg size-full
-            border-t-transparent"
+            className="size-full rounded-b-lg
+            border border-grey-200 border-t-transparent p-8
+            focus:outline-blue-400"
             aria-label="Assignee"
             placeholder={'시/군/구 선택'}
             defaultValue={null}
             displayValue={(smallRegion: string | null) => smallRegion ?? ''}
             onChange={(event) => setQuerySmall(event.target.value)}
+            autoComplete="off"
           />
           <ComboboxOptions
             anchor="bottom"
-            className="w-[var(--input-width)] shadow-md bg-white rounded-lg empty:invisible mt-4"
+            className="mt-4 w-[var(--input-width)] rounded-lg bg-white shadow-md empty:invisible"
           >
             {filteredSmallRegions.map((smallRegion) => (
               <ComboboxOption
                 key={smallRegion}
                 value={smallRegion}
-                className="data-[focus]:bg-blue-100 p-8"
+                className="p-8 data-[focus]:bg-blue-100"
               >
                 {smallRegion}
               </ComboboxOption>

--- a/src/types/shuttleRoute.type.ts
+++ b/src/types/shuttleRoute.type.ts
@@ -36,7 +36,6 @@ export const ShuttleRouteHubsInShuttleRoutesViewEntitySchema = z
     status: z.enum(['ACTIVE', 'INACTIVE']),
   })
   .strict();
-
 export type ShuttleRouteHubsInShuttleRoutesViewEntity = z.infer<
   typeof ShuttleRouteHubsInShuttleRoutesViewEntitySchema
 >;
@@ -71,7 +70,6 @@ export const ShuttleRoutesViewEntitySchema = z
     updatedAt: z.string(),
   })
   .strict();
-
 export type ShuttleRoutesViewEntity = z.infer<
   typeof ShuttleRoutesViewEntitySchema
 >;
@@ -107,7 +105,6 @@ export const CreateShuttleRouteRequestSchema = z
       .array(),
   })
   .strict();
-
 export type CreateShuttleRouteRequest = z.infer<
   typeof CreateShuttleRouteRequestSchema
 >;
@@ -119,7 +116,6 @@ export const UpdateShuttleRouteHubPropsSchema = z.object({
   sequence: z.number().int().positive(),
   arrivalTime: z.string(),
 });
-
 export type UpdateShuttleRouteHubProps = z.infer<
   typeof UpdateShuttleRouteHubPropsSchema
 >;
@@ -130,7 +126,6 @@ export const UpdateShuttleRouteRequestSchema = z.object({
   maxPassengerCount: z.number().int(),
   shuttleRouteHubs: UpdateShuttleRouteHubPropsSchema.array(),
 });
-
 export type UpdateShuttleRouteRequest = z.infer<
   typeof UpdateShuttleRouteRequestSchema
 >;


### PR DESCRIPTION
## 개요

노선 생성 페이지에서 경유지를 입력할 때 목적지행의 경유지들을 귀가행에 미러링 할 수 있는 기능을 추가했습니다.

## 변경사항


https://github.com/user-attachments/assets/e72b19b1-0753-4f03-af9f-ce300bfba586



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).