### PR TITLE
feat: 행사 수정 페이지

### DIFF
--- a/src/app/events/[eventId]/(home)/page.tsx
+++ b/src/app/events/[eventId]/(home)/page.tsx
@@ -37,10 +37,14 @@ const Page = ({ params: { eventId } }: Props) => {
 
   return (
     <main className="flex size-full flex-col gap-16 bg-white ">
-      <Heading>행사 상세 정보</Heading>
+      <Heading className="flex items-baseline gap-20">
+        행사 상세 정보
+        <BlueLink href={`${eventId}/edit`} className="text-14">
+          수정하기
+        </BlueLink>
+      </Heading>
       <div className="flex flex-row flex-wrap gap-4 rounded-lg border border-grey-100 p-8 text-14">
         <JSONViewer value={event} />
-        <BlueLink href={`${eventId}/edit`}>수정</BlueLink>
         <BlueLink href={`/demands/${eventId}`}>
           이 행사의 수요 조사 조회
         </BlueLink>

--- a/src/app/events/[eventId]/edit/page.tsx
+++ b/src/app/events/[eventId]/edit/page.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { type EditEventFormData, conform } from './types/form.type';
+import { useRouter } from 'next/navigation';
+import ArtistInput from '@/components/input/ArtistInput';
+import { Controller } from 'react-hook-form';
+import RegionInput from '@/components/input/RegionInput';
+import { CheckIcon, PlusIcon, XIcon } from 'lucide-react';
+import { Button, Field, Label, RadioGroup, Radio } from '@headlessui/react';
+import ImageFileInput from '@/components/input/ImageFileInput';
+import RegionHubInput from '@/components/input/HubInput';
+import Input from '@/components/input/Input';
+import dayjs from 'dayjs';
+import { useGetEvent, usePutEvent } from '@/services/shuttleOperation.service';
+import Form from '@/components/form/Form';
+import { EventsViewEntity } from '@/types/event.type';
+
+interface Props {
+  params: { eventId: string };
+}
+
+const EditEventPage = ({ params }: Props) => {
+  const { eventId } = params;
+  const {
+    data: event,
+    isLoading,
+    isError,
+    error,
+  } = useGetEvent(Number(eventId));
+
+  const defaultValues = useMemo(() => {
+    if (!event) return {} as EditEventFormData;
+    return {
+      status: event?.eventStatus,
+      name: event?.eventName,
+      imageUrl: event?.eventImageUrl,
+      regionId: event?.regionId,
+      regionHubId: event?.regionHubId,
+      type: event?.eventType,
+      dailyEvents: event?.dailyEvents?.map((dailyEvent) => ({
+        status: dailyEvent.status,
+        dailyEventId: dailyEvent.dailyEventId,
+        date: dailyEvent.date,
+      })),
+      artistIds:
+        event?.eventArtists?.map((artist) => ({
+          artistId: artist.artistId ?? null,
+        })) ?? [],
+    } satisfies EditEventFormData;
+  }, [event]);
+
+  return (
+    <>
+      {isLoading && <div>Loading...</div>}
+      {isError && <div>{error?.message}</div>}
+      {event && <EditEventForm event={event} defaultValues={defaultValues} />}
+    </>
+  );
+};
+
+export default EditEventPage;
+
+interface EditEventFormProps {
+  event: EventsViewEntity;
+  defaultValues: EditEventFormData;
+}
+
+const EditEventForm = ({ event, defaultValues }: EditEventFormProps) => {
+  const router = useRouter();
+
+  const {
+    control,
+    handleSubmit,
+    // formState: { errors },
+  } = useForm<EditEventFormData>({
+    defaultValues,
+  });
+
+  const watch = useWatch({
+    control,
+    exact: false,
+  });
+
+  const {
+    fields: dailyFields,
+    append: appendDaily,
+    remove: removeDaily,
+  } = useFieldArray<EditEventFormData>({
+    control,
+    name: 'dailyEvents',
+  });
+
+  const {
+    fields: concertArtistFields,
+    append: appendArtist,
+    remove: removeArtist,
+  } = useFieldArray<EditEventFormData>({
+    control,
+    name: 'artistIds',
+  });
+
+  const { mutate: putEvent } = usePutEvent({
+    onSuccess: () => {
+      alert('행사가 수정되었습니다.');
+      router.push(`/events/${event.eventId}`);
+    },
+    onError: (error) => {
+      if (error instanceof Error && error.message === 'NEXT_REDIRECT') {
+        throw error;
+      }
+      console.error('Error editing events:', error);
+      alert(
+        '행사 수정에 실패했습니다, ' +
+          (error instanceof Error && error.message),
+      );
+      throw error;
+    },
+  });
+
+  const onSubmit = useCallback(
+    async (data: EditEventFormData) => {
+      if (confirm('행사를 수정하시겠습니까?')) {
+        putEvent({ eventId: event.eventId, body: conform(data) });
+      }
+    },
+    [event, putEvent],
+  );
+
+  return (
+    <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form.section>
+        <Form.label>행사 이름</Form.label>
+        <Controller
+          control={control}
+          name="name"
+          render={({ field: { onChange, value } }) => (
+            <Input
+              type="text"
+              value={value}
+              placeholder="행사 이름"
+              setValue={onChange}
+            />
+          )}
+        />
+      </Form.section>
+      <Form.section>
+        <Form.label>장소</Form.label>
+        <Controller
+          control={control}
+          name="regionId"
+          render={({ field: { onChange, value } }) => (
+            <RegionInput
+              value={value}
+              setValue={(id) => onChange(id || null)}
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name="regionHubId"
+          render={({ field: { onChange, value } }) => (
+            <RegionHubInput
+              regionId={watch.regionId}
+              value={value}
+              setValue={(n) => onChange(n)}
+            />
+          )}
+        />
+      </Form.section>
+      <Form.section>
+        <Form.label>
+          날짜
+          <button
+            type="button"
+            onClick={() =>
+              appendDaily({
+                date: dayjs().format('YYYY-MM-DD'),
+              })
+            }
+            className="w-fit text-blue-500"
+          >
+            <PlusIcon />
+          </button>
+        </Form.label>
+        <div className="flex w-full flex-col gap-4">
+          {dailyFields.map((field, index) => (
+            <Controller
+              key={field.id}
+              control={control}
+              name={`dailyEvents.${index}` as const}
+              render={({ field: { onChange, value } }) => (
+                <div className="flex w-full flex-col">
+                  <div className="flex w-full flex-row items-center">
+                    <Input
+                      type="date"
+                      className="w-full"
+                      value={dayjs(value.date).format('YYYY-MM-DD')}
+                      // TODO check timezone issue
+                      setValue={(str) =>
+                        onChange({
+                          ...value,
+                          date: dayjs(str).format('YYYY-MM-DD'),
+                        })
+                      }
+                    />
+                    {!value.dailyEventId && (
+                      <button type="button" onClick={() => removeDaily(index)}>
+                        <XIcon />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            />
+          ))}
+        </div>
+      </Form.section>
+      <Form.section>
+        <Form.label>타입</Form.label>
+        <Controller
+          control={control}
+          name="type"
+          render={({ field: { onChange, value } }) => (
+            <RadioGroup
+              value={value}
+              className="flex flex-row gap-4"
+              onChange={(s) => onChange(s)}
+              aria-label="Server size"
+            >
+              {['CONCERT', 'FESTIVAL'].map((plan) => (
+                <Field key={plan} className="gap-2 flex items-center">
+                  <Radio
+                    value={plan}
+                    className="group flex size-fit items-center justify-center rounded-lg bg-white p-4
+                    transition-transform
+                    hover:outline
+                    hover:outline-blue-200
+                    focus:outline
+                    focus:outline-blue-200
+                    active:scale-[0.9]
+                    data-[checked]:bg-blue-400
+                    data-[checked]:text-white
+                    "
+                  >
+                    <CheckIcon
+                      className="invisible group-data-[checked]:visible"
+                      size={18}
+                    />
+                    <Label>{plan}</Label>
+                  </Radio>
+                </Field>
+              ))}
+            </RadioGroup>
+          )}
+        />
+      </Form.section>
+      <Form.section>
+        <Form.label>행사 이미지</Form.label>
+        <Controller
+          control={control}
+          name="imageUrl"
+          render={({ field: { onChange, value } }) => (
+            <ImageFileInput
+              type="concerts"
+              value={value}
+              setValue={(url) => onChange(url || null)}
+            />
+          )}
+        />
+      </Form.section>
+      <Form.section>
+        <Form.label>
+          아티스트{' '}
+          <button
+            type="button"
+            onClick={() => appendArtist({ artistId: null })}
+            className="w-fit text-blue-500"
+          >
+            <PlusIcon />
+          </button>
+        </Form.label>
+        <div className="flex flex-col gap-4">
+          {concertArtistFields.map((field, index) => (
+            <div key={field.id} className="flex gap-4">
+              <Controller
+                control={control}
+                name={`artistIds.${index}.artistId`}
+                render={({ field: { onChange, value } }) => (
+                  <ArtistInput
+                    value={value}
+                    setValue={(id) => onChange(id || null)}
+                  />
+                )}
+              />
+              <Button
+                className="transition-colors hover:text-red-500"
+                type="button"
+                onClick={() => removeArtist(index)}
+              >
+                <XIcon />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </Form.section>
+      <Form.submitButton>수정하기</Form.submitButton>
+    </Form>
+  );
+};

--- a/src/app/events/[eventId]/edit/types/form.type.ts
+++ b/src/app/events/[eventId]/edit/types/form.type.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import {
+  EventStatusEnum,
+  EventTypeEnum,
+  UpdateEventRequest,
+} from '@/types/event.type';
+
+export const EditEventFormSchema = z.object({
+  status: EventStatusEnum,
+  name: z.string(),
+  imageUrl: z.string().url(),
+  regionId: z.number().int(),
+  regionHubId: z.number().int(),
+  dailyEvents: z
+    .object({
+      status: EventStatusEnum.optional(),
+      dailyEventId: z.number().int().optional(),
+      date: z.string(),
+    })
+    .array(),
+  type: EventTypeEnum,
+  artistIds: z.array(z.object({ artistId: z.number().int().nullable() })),
+});
+
+export type EditEventFormData = z.infer<typeof EditEventFormSchema>;
+
+//TODO: 왜 artistIds 가 null 인지 체크하도록 코드를 짜두셨을까?
+export const conform = (data: EditEventFormData): UpdateEventRequest => {
+  const artistIds = data.artistIds.filter(
+    (artist): artist is { artistId: number } => artist.artistId !== null,
+  );
+  return {
+    ...data,
+    artistIds: artistIds.map((artist) => artist.artistId),
+  } satisfies UpdateEventRequest;
+};

--- a/src/app/events/[eventId]/edit/types/form.type.ts
+++ b/src/app/events/[eventId]/edit/types/form.type.ts
@@ -24,7 +24,6 @@ export const EditEventFormSchema = z.object({
 
 export type EditEventFormData = z.infer<typeof EditEventFormSchema>;
 
-//TODO: 왜 artistIds 가 null 인지 체크하도록 코드를 짜두셨을까?
 export const conform = (data: EditEventFormData): UpdateEventRequest => {
   const artistIds = data.artistIds.filter(
     (artist): artist is { artistId: number } => artist.artistId !== null,

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -16,6 +16,7 @@ import dayjs from 'dayjs';
 import { today, toDateOnly } from '@/utils/date.util';
 import { usePostEvent } from '@/services/shuttleOperation.service';
 import Form from '@/components/form/Form';
+import { EventTypeEnum } from '@/types/event.type';
 
 const defaultValues = {
   name: '',
@@ -30,11 +31,7 @@ const defaultValues = {
 const CreateEventForm = () => {
   const router = useRouter();
 
-  const {
-    control,
-    handleSubmit,
-    // formState: { errors },
-  } = useForm<CreateEventFormData>({
+  const { control, handleSubmit } = useForm<CreateEventFormData>({
     defaultValues,
   });
 
@@ -67,25 +64,21 @@ const CreateEventForm = () => {
       router.push('/events');
     },
     onError: (error) => {
-      if (error instanceof Error && error.message === 'NEXT_REDIRECT') {
-        throw error;
-      }
       console.error('Error creating events:', error);
       alert(
         '행사 추가에 실패했습니다, ' +
           (error instanceof Error && error.message),
       );
-      throw error;
     },
   });
 
   const onSubmit = useCallback(
-    async (data: CreateEventFormData) => {
+    (data: CreateEventFormData) => {
       if (confirm('행사를 추가하시겠습니까?')) {
         postEvent(conform(data));
       }
     },
-    [router, postEvent],
+    [postEvent],
   );
 
   return (
@@ -153,7 +146,6 @@ const CreateEventForm = () => {
                       type="date"
                       className="w-full"
                       value={dayjs(value).format('YYYY-MM-DD')}
-                      // TODO check timezone issue
                       setValue={(str) => onChange(toDateOnly(new Date(str)))}
                     />
                     <button type="button" onClick={() => removeDaily(index)}>
@@ -178,7 +170,7 @@ const CreateEventForm = () => {
               onChange={(s) => onChange(s)}
               aria-label="Server size"
             >
-              {['CONCERT', 'FESTIVAL'].map((plan) => (
+              {EventTypeEnum.options.map((plan) => (
                 <Field key={plan} className="gap-2 flex items-center">
                   <Radio
                     value={plan}

--- a/src/services/shuttleOperation.service.ts
+++ b/src/services/shuttleOperation.service.ts
@@ -13,6 +13,8 @@ import {
   CreateEventRequestSchema,
   EventStatus,
   EventsViewEntitySchema,
+  UpdateEventRequest,
+  UpdateEventRequestSchema,
 } from '@/types/event.type';
 import {
   CreateShuttleRouteRequest,
@@ -478,6 +480,33 @@ export const usePostEvent = ({
       queryClient.invalidateQueries({ queryKey: ['event'] });
       onSuccess?.();
     },
+    onError,
+  });
+};
+
+export const putEvent = async (eventId: number, body: UpdateEventRequest) => {
+  await authInstance.put(
+    `/v2/shuttle-operation/admin/events/${eventId}`,
+    silentParse(UpdateEventRequestSchema, body),
+  );
+};
+
+export const usePutEvent = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+} = {}) => {
+  return useMutation({
+    mutationFn: ({
+      eventId,
+      body,
+    }: {
+      eventId: number;
+      body: UpdateEventRequest;
+    }) => putEvent(eventId, body),
+    onSuccess,
     onError,
   });
 };

--- a/src/types/event.type.ts
+++ b/src/types/event.type.ts
@@ -61,3 +61,24 @@ export const CreateEventRequestSchema = z.object({
 });
 
 export type CreateEventRequest = z.infer<typeof CreateEventRequestSchema>;
+
+export const UpdateEventRequestSchema = z
+  .object({
+    status: EventStatusEnum,
+    name: z.string(),
+    imageUrl: z.string().url(),
+    regionId: z.number().int(),
+    regionHubId: z.number().int(),
+    dailyEvents: z
+      .object({
+        status: EventStatusEnum.optional(),
+        dailyEventId: z.number().int().optional(),
+        date: z.string(),
+      })
+      .array(),
+    type: EventTypeEnum,
+    artistIds: z.number().int().array(),
+  })
+  .partial();
+
+export type UpdateEventRequest = z.infer<typeof UpdateEventRequestSchema>;


### PR DESCRIPTION
## 개요

행사 수정 페이지가 추가되었습니다.
- 일일행사의 수정전 데이터를 병렬 표기하였습니다.
- 새로운 일일행사 칼럼을 추가할 수 있습니다. 이런 경우엔 X 버튼이 표시되고 수정 및 삭제할 수 있습니다.


https://github.com/user-attachments/assets/d7d1b192-11ce-473a-8b8e-9795efe0bb73



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).