### PR TITLE
feat: Hub/Artist input 에 새 거점지/아티스트 추가하기 버튼 삽입

### DIFF
--- a/src/components/input/ArtistInput.tsx
+++ b/src/components/input/ArtistInput.tsx
@@ -10,6 +10,7 @@ import {
 import { filterByFuzzy } from '@/utils/fuzzy.util';
 import { useGetArtists } from '@/services/shuttleOperation.service';
 import { ArtistsViewEntity } from '@/types/artist.type';
+import Link from 'next/link';
 
 interface Props {
   value: string | null;
@@ -73,6 +74,16 @@ const ArtistInput = ({ value, setValue }: Props) => {
             {artist.artistName}
           </ComboboxOption>
         ))}
+        {!isLoading && (
+          <Link
+            href="/artists/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block p-8 text-blue-500 hover:bg-blue-100"
+          >
+            + 새로운 아티스트 만들기
+          </Link>
+        )}
       </ComboboxOptions>
     </Combobox>
   );

--- a/src/components/input/HubInput.tsx
+++ b/src/components/input/HubInput.tsx
@@ -104,18 +104,16 @@ const RegionHubInput = ({ regionId, value, setValue }: Props) => {
               {hub.name}
             </ComboboxOption>
           ))}
-          {regionHubs?.length === 0 &&
-            !isLoading &&
-            validRegionID(regionId) && (
-              <Link
-                href="/hubs/new"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block p-8 text-blue-500 hover:bg-blue-50"
-              >
-                + 새로운 거점 만들기
-              </Link>
-            )}
+          {!isLoading && validRegionID(regionId) && (
+            <Link
+              href="/hubs/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block p-8 text-blue-500 hover:bg-blue-100"
+            >
+              + 새로운 거점 만들기
+            </Link>
+          )}
         </ComboboxOptions>
       </div>
     </Combobox>

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -14,7 +14,6 @@ const Nav = async () => {
       <NavItem href="/demands">수요조사</NavItem>
       <NavItem href="/reservations">예약</NavItem>
       <NavItem href="/hubs">거점지</NavItem>
-      <NavItem href="/artists">아티스트</NavItem>
       <NavItem href="/coupons">쿠폰</NavItem>
       <Link
         href="/login"


### PR DESCRIPTION
## 개요
- 네비게이션바 - 아티스트가 사라집니다. 행사 - 행사추가/수정하기 페이지에서 접근할 수 있습니다.
- 거점지 : 이전엔 해당 시/도-시/군/구 선택후 거점지가 없을경우 새 거점지 추가하기 버튼이 표시됐는데, 언제나 표기됩니다.
- 아티스트 : 새 아티스트 추가하기 버튼이 표시됩니다.

<img width="946" alt="Screenshot 2025-02-06 at 4 23 12 PM" src="https://github.com/user-attachments/assets/4f4cab76-da40-4388-a65b-11cc1eb736ce" />
<img width="944" alt="Screenshot 2025-02-06 at 4 23 04 PM" src="https://github.com/user-attachments/assets/f55d7c9f-d36e-4a83-b8c2-7e427196eb05" />




## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).