### PR TITLE
fix: 카카오맵 스크립트 중복 로드 방지

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/page.tsx
@@ -118,7 +118,7 @@ const Page = ({ params }: Props) => {
     }
   }, [demandsStats, routeTree]);
 
-  const { KakaoScript } = useKakaoMap({
+  useKakaoMap({
     onReady: () => setIsScriptReady(true),
     libraries: ['services'],
   });
@@ -342,104 +342,99 @@ const Page = ({ params }: Props) => {
   };
 
   return (
-    <>
-      <KakaoScript />
-      <main className="flex grow flex-col">
-        <Heading>수요조사 대시보드</Heading>
-        <div className="flex grow gap-12">
-          <div className="relative flex grow flex-col" ref={mapRef}>
-            {viewingRegion && (
-              <section className="absolute bottom-0 left-0 top-0 z-50 w-240 bg-black/55 p-12 text-white">
-                <h5 className="text-18 font-600">{viewingRegion}</h5>
-                <article className="flex flex-col p-4 text-12 text-grey-100">
-                  {(() => {
-                    const demand = demandsStats?.find(
-                      (demand) => demand.provinceFullName === viewingRegion,
-                    );
-                    if (!demand) {
-                      return null;
-                    }
+    <main className="flex grow flex-col">
+      <Heading>수요조사 대시보드</Heading>
+      <div className="flex grow gap-12">
+        <div className="relative flex grow flex-col" ref={mapRef}>
+          {viewingRegion && (
+            <section className="absolute bottom-0 left-0 top-0 z-50 w-240 bg-black/55 p-12 text-white">
+              <h5 className="text-18 font-600">{viewingRegion}</h5>
+              <article className="flex flex-col p-4 text-12 text-grey-100">
+                {(() => {
+                  const demand = demandsStats?.find(
+                    (demand) => demand.provinceFullName === viewingRegion,
+                  );
+                  if (!demand) {
+                    return null;
+                  }
+                  return (
+                    <>
+                      <p>총 수요: {demand.totalCount}개</p>
+                      <p>왕복 수요: {demand.roundTripCount}개</p>
+                      <p>가는 편 수요: {demand.toDestinationCount}개</p>
+                      <p>오는 편 수요: {demand.fromDestinationCount}개</p>
+                    </>
+                  );
+                })()}
+              </article>
+              <article className="flex flex-col gap-4 text-grey-50">
+                <h6 className="flex items-center gap-4 pt-8 text-14 font-600">
+                  {viewingRegion} 내 군집들
+                  <ToolTip iconClassName="text-grey-300 hover:text-grey-100">
+                    기타 수요조사는 지도 및 군집에 표시되지 않습니다.
+                  </ToolTip>
+                </h6>
+                <ul className="flex flex-col gap-[1px]">
+                  {clustersInRegion.current?.[viewingRegion]?.map((cluster) => {
                     return (
-                      <>
-                        <p>총 수요: {demand.totalCount}개</p>
-                        <p>왕복 수요: {demand.roundTripCount}개</p>
-                        <p>가는 편 수요: {demand.toDestinationCount}개</p>
-                        <p>오는 편 수요: {demand.fromDestinationCount}개</p>
-                      </>
-                    );
-                  })()}
-                </article>
-                <article className="flex flex-col gap-4 text-grey-50">
-                  <h6 className="flex items-center gap-4 pt-8 text-14 font-600">
-                    {viewingRegion} 내 군집들
-                    <ToolTip iconClassName="text-grey-300 hover:text-grey-100">
-                      기타 수요조사는 지도 및 군집에 표시되지 않습니다.
-                    </ToolTip>
-                  </h6>
-                  <ul className="flex flex-col gap-[1px]">
-                    {clustersInRegion.current?.[viewingRegion]?.map(
-                      (cluster) => {
-                        return (
-                          <button
-                            key={cluster.clusterId}
-                            className="flex items-center justify-between p-4 text-14 hover:bg-grey-100/50"
-                            onClick={() => handleHubClick(cluster)}
-                          >
-                            <span>{cluster.nodes[0].data.regionHubName}</span>
-                            <span className="text-12 text-grey-200">
-                              {cluster.totalCount}개
-                            </span>
-                          </button>
-                        );
-                      },
-                    )}
-                  </ul>
-                </article>
-              </section>
-            )}
-          </div>
-          <section className="flex w-320 flex-col gap-4 bg-white p-12 shadow-[0px_0px_10px_0px_rgba(0,0,0,0.18)]">
-            <Heading.h5 className="flex items-baseline gap-8 bg-notion-grey">
-              추천 노선
-              <p className="text-10 text-grey-500">
-                정류장 간의 순서는 최적의 순서가 보장되지 않습니다.
-              </p>
-            </Heading.h5>
-            <ul className="flex grow flex-col gap-12 overflow-y-auto">
-              {routeTree?.routes.map((route, index) => (
-                <button
-                  key={index}
-                  className={twMerge(
-                    'flex items-center gap-8 overflow-x-auto px-4 py-8 hover:bg-notion-grey/70',
-                    selectedRouteIndex === index && 'bg-notion-grey/70',
-                  )}
-                  onClick={() => handleRouteClick(route, index)}
-                >
-                  {route.nodes.map((node, index) => {
-                    const cluster = routeTree?.clusters.find(
-                      (cluster) => cluster.clusterId === node,
-                    );
-                    if (!cluster) {
-                      return null;
-                    }
-                    return (
-                      <>
-                        <span className="h-full whitespace-nowrap break-keep">
-                          {cluster.nodes[0].data.regionHubName}
+                      <button
+                        key={cluster.clusterId}
+                        className="flex items-center justify-between p-4 text-14 hover:bg-grey-100/50"
+                        onClick={() => handleHubClick(cluster)}
+                      >
+                        <span>{cluster.nodes[0].data.regionHubName}</span>
+                        <span className="text-12 text-grey-200">
+                          {cluster.totalCount}개
                         </span>
-                        {index !== route.nodes.length - 1 && (
-                          <span className="text-grey-500">-</span>
-                        )}
-                      </>
+                      </button>
                     );
                   })}
-                </button>
-              ))}
-            </ul>
-          </section>
+                </ul>
+              </article>
+            </section>
+          )}
         </div>
-      </main>
-    </>
+        <section className="flex w-320 flex-col gap-4 bg-white p-12 shadow-[0px_0px_10px_0px_rgba(0,0,0,0.18)]">
+          <Heading.h5 className="flex items-baseline gap-8 bg-notion-grey">
+            추천 노선
+            <p className="text-10 text-grey-500">
+              정류장 간의 순서는 최적의 순서가 보장되지 않습니다.
+            </p>
+          </Heading.h5>
+          <ul className="flex grow flex-col gap-12 overflow-y-auto">
+            {routeTree?.routes.map((route, index) => (
+              <button
+                key={index}
+                className={twMerge(
+                  'flex items-center gap-8 overflow-x-auto px-4 py-8 hover:bg-notion-grey/70',
+                  selectedRouteIndex === index && 'bg-notion-grey/70',
+                )}
+                onClick={() => handleRouteClick(route, index)}
+              >
+                {route.nodes.map((node, index) => {
+                  const cluster = routeTree?.clusters.find(
+                    (cluster) => cluster.clusterId === node,
+                  );
+                  if (!cluster) {
+                    return null;
+                  }
+                  return (
+                    <>
+                      <span className="h-full whitespace-nowrap break-keep">
+                        {cluster.nodes[0].data.regionHubName}
+                      </span>
+                      {index !== route.nodes.length - 1 && (
+                        <span className="text-grey-500">-</span>
+                      )}
+                    </>
+                  );
+                })}
+              </button>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
   );
 };
 

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -39,6 +39,7 @@ const CoordInput = ({ coord, setCoord }: Props) => {
   );
 
   const setMarker = useCallback((latLng: kakao.maps.LatLng) => {
+    console.log('setMarker', latLng);
     if (markerRef.current === null) setError(true);
     else markerRef.current.setPosition(latLng);
   }, []);
@@ -67,6 +68,7 @@ const CoordInput = ({ coord, setCoord }: Props) => {
   };
 
   const initializeMap = useCallback(() => {
+    console.log('initializeMap');
     try {
       if (window.kakao && mapRef.current) {
         const options = {
@@ -111,16 +113,15 @@ const CoordInput = ({ coord, setCoord }: Props) => {
       setError(true);
       alert('지도를 불러오는 중 오류가 발생했습니다. \n' + error);
     }
-  }, [setCoordWithAddress, coord]);
+  }, []);
 
-  const { KakaoScript } = useKakaoMap({
+  useKakaoMap({
     onReady: () => window.kakao.maps.load(initializeMap),
     libraries: ['services'],
   });
 
   return (
     <article className="relative h-auto p-16 [&_div]:cursor-pointer">
-      <KakaoScript />
       <div className="relative rounded-[12px] transition-opacity">
         <div
           ref={mapRef}

--- a/src/hooks/useKakaoMap.tsx
+++ b/src/hooks/useKakaoMap.tsx
@@ -1,4 +1,6 @@
-import Script from 'next/script';
+import { useEffect } from 'react';
+
+const KAKAO_MAP_SCRIPT_ID = 'kakao-map-script';
 
 interface Props {
   onReady?: () => void;
@@ -6,19 +8,28 @@ interface Props {
 }
 
 const useKakaoMap = ({ onReady, libraries = [] }: Props = {}) => {
-  const KakaoScript = () => {
-    const librariesString = libraries?.join(',');
-    return (
-      <Script
-        id="kakao-maps-sdk"
-        strategy="afterInteractive"
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=${librariesString}`}
-        onReady={onReady}
-      />
-    );
-  };
+  useEffect(() => {
+    const isScript = document.getElementById(KAKAO_MAP_SCRIPT_ID);
+    const mapScript = document.createElement('script');
 
-  return { KakaoScript };
+    const librariesString = libraries?.join(',');
+
+    if (!isScript) {
+      mapScript.id = KAKAO_MAP_SCRIPT_ID;
+      mapScript.async = true;
+      mapScript.type = 'text/javascript';
+      mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=${librariesString}`;
+      document.head.appendChild(mapScript);
+    }
+
+    mapScript.addEventListener('load', () => {
+      onReady?.();
+    });
+
+    return () => {
+      mapScript.removeEventListener('load', () => onReady?.());
+    };
+  }, []);
 };
 
 export default useKakaoMap;


### PR DESCRIPTION
## 개요

카카오맵 커스텀훅에서 스크립트 중복 로드가 안되도록 수정했습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).