### PR TITLE
fix: 무한스크롤 중복 요청 방지 및 debounced input 적용

### DIFF
--- a/src/app/reservations/components/ReservationFilter.tsx
+++ b/src/app/reservations/components/ReservationFilter.tsx
@@ -6,7 +6,6 @@ import {
   DisclosurePanel,
 } from '@headlessui/react';
 import { ChevronDownIcon, FilterIcon, FilterXIcon } from 'lucide-react';
-import Input from '@/components/input/Input';
 import { Dispatch, useMemo } from 'react';
 import { twMerge } from 'tailwind-merge';
 import EventInput from '@/components/input/EventInput';
@@ -27,6 +26,7 @@ import {
   HandyStatusEnum,
   ReservationStatusEnum,
 } from '@/types/reservation.type';
+import DebouncedInput from '@/components/input/DebouncedInput';
 
 interface Props {
   option: GetReservationsOptions;
@@ -130,7 +130,7 @@ function ReservationFilter({ option, dispatch }: Props) {
           </>
         )}
         <label>유저 닉네임 (fuzzy)</label>
-        <Input
+        <DebouncedInput
           value={option.userNickname ?? ''}
           setValue={(n) =>
             dispatch({
@@ -140,7 +140,7 @@ function ReservationFilter({ option, dispatch }: Props) {
           }
         />
         <label>탑승자 이름 (fuzzy)</label>
-        <Input
+        <DebouncedInput
           value={option.passengerName ?? ''}
           setValue={(n) =>
             dispatch({

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -34,7 +34,11 @@ const AllReservations = () => {
       limit: PAGINATION_LIMIT,
     });
 
-  const ref = useInfiniteScroll(fetchNextPage);
+  const { InfiniteScrollTrigger } = useInfiniteScroll({
+    fetchNextPage,
+    isLoading: isFetching,
+    hasNextPage,
+  });
 
   const flatData = useMemo(
     () => data.pages.flatMap((page) => page.reservations),
@@ -56,7 +60,7 @@ const AllReservations = () => {
       {flatData.length === 0 && !isFetching && <p>데이터가 없습니다.</p>}
       {isError ? <p>에러 : {error.message}</p> : null}
       {isFetching ? <LoaderCircleIcon className="animate-spin" /> : null}
-      {hasNextPage && <div ref={ref} />}
+      <InfiniteScrollTrigger />
     </section>
   );
 };

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -76,7 +76,11 @@ const Page = () => {
     limit: PAGINATION_LIMIT,
   });
 
-  const ref = useInfiniteScroll(fetchNextPage);
+  const { InfiniteScrollTrigger } = useInfiniteScroll({
+    fetchNextPage,
+    isLoading: isFetching,
+    hasNextPage,
+  });
 
   const flattenedUsers = useMemo(
     () => users?.pages.flatMap((page) => page.users) || [],
@@ -133,7 +137,7 @@ const Page = () => {
         </>
       )}
       {isFetchingNextPage && <Loading />}
-      {hasNextPage && <div ref={ref} />}
+      <InfiniteScrollTrigger />
     </main>
   );
 };

--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -7,17 +7,21 @@ import type {
   InfiniteQueryObserverResult,
 } from '@tanstack/react-query';
 
-/**
- * trigger fetchNextPage when the ref is intersecting.
- *
- * @param fetchNextPage comes from result of useInfiniteQuery
- * @returns ref which is HTMLDivElement
- */
-const useInfiniteScroll = <TData, TError>(
+interface Props {
   fetchNextPage: (
     options?: FetchNextPageOptions,
-  ) => Promise<InfiniteQueryObserverResult<TData, TError>>,
-) => {
+  ) => Promise<InfiniteQueryObserverResult<unknown, unknown>>;
+  isLoading?: boolean;
+  hasNextPage?: boolean;
+  className?: string;
+}
+
+const useInfiniteScroll = ({
+  fetchNextPage,
+  isLoading,
+  hasNextPage,
+  className,
+}: Props) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const useObserver = ({
@@ -55,7 +59,16 @@ const useInfiniteScroll = <TData, TError>(
     onIntersect,
   });
 
-  return ref;
+  const InfiniteScrollTrigger = () => {
+    return (
+      <div
+        ref={ref}
+        className={`${isLoading || !hasNextPage ? 'hidden' : ''} ${className}`}
+      />
+    );
+  };
+
+  return { InfiniteScrollTrigger };
 };
 
 export default useInfiniteScroll;


### PR DESCRIPTION
## 개요

무한스크롤 커스텀 훅에서 다음 페이지 요청이 중복으로 들어가는 현상을 해결했습니다.
또한 debounced input을 필터가 있는 곳에 모두 적용시켰습니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).