### PR TITLE
fix: 예약관리에서 핸디 선발 안되던 이슈

### DIFF
--- a/src/app/reservations/table.type.tsx
+++ b/src/app/reservations/table.type.tsx
@@ -6,6 +6,7 @@ import Stringifier from '@/utils/stringifier.util';
 import { formatDateString } from '@/utils/date.util';
 import { ReservationViewEntity } from '@/types/reservation.type';
 import { dayjsTz } from '@/utils/date.util';
+import EditHandyStatusDialog from '@/components/dialog/EditHandyStatusDialog';
 
 const columnHelper = createColumnHelper<ReservationViewEntity>();
 
@@ -90,15 +91,8 @@ export const columns = [
     id: 'handyActions',
     header: '핸디 승인',
     cell: (props) =>
-      props.row.original.handyStatus === 'SUPPORTED' && (
-        <>
-          <BlueLink href={`/reservations/${props.row.original.reservationId}`}>
-            승인하기
-          </BlueLink>
-          <BlueLink href={`/reservations/${props.row.original.reservationId}`}>
-            거절하기
-          </BlueLink>
-        </>
+      props.row.original.handyStatus !== 'NOT_SUPPORTED' && (
+        <EditHandyStatusDialog response={props.row.original} />
       ),
   }),
   columnHelper.display({


### PR DESCRIPTION
## 개요
기존에 핸디선발/거절을 누르면 예약상세로 리디렉트 되던 이슈를 해결하였습니다.

https://github.com/user-attachments/assets/0343a210-1bfc-4636-a0a6-84136c994e0f


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).