### PR TITLE
feat: breadcrumb 고도화

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/[eventId_tmp]/dates/[dailyEventId_tmp]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/[eventId_tmp]/dates/[dailyEventId_tmp]/table.type.tsx
@@ -16,7 +16,7 @@ export const columnsFrom = [
   }),
   columnHelper.accessor('regionHubName', {
     id: 'regionHubName',
-    header: '귀가행 지역 거점지 이름',
+    header: '귀가행 정류장 이름',
     cell: (info) => info.getValue(),
   }),
   columnHelper.accessor('totalCount', {
@@ -49,7 +49,7 @@ export const columnsTo = [
   }),
   columnHelper.accessor('regionHubName', {
     id: 'regionHubName',
-    header: '목적지행 지역 거점지 이름',
+    header: '목적지행 정류장 이름',
     cell: (info) => info.getValue(),
   }),
   columnHelper.accessor('totalCount', {

--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/table.type.tsx
@@ -48,12 +48,12 @@ export const columnsForGroupByEventId = [
   // }),
   // columnHelper.accessor('toDestinationRegionHubName', {
   //   id: 'toDestinationRegionHubName',
-  //   header: '목적지행 지역 거점지 이름',
+  //   header: '목적지행 정류장 이름',
   //   cell: (info) => info.getValue(),
   // }),
   // columnHelper.accessor('fromDestinationRegionHubName', {
   //   id: 'fromDestinationRegionHubName',
-  //   header: '귀가행 지역 거점지 이름',
+  //   header: '귀가행 정류장 이름',
   //   cell: (info) => info.getValue(),
   // }),
   columnHelper.accessor('totalCount', {

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
@@ -165,7 +165,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
         error instanceof Error &&
         error.message === 'arrivalTime is not validated'
       )
-        alert('거점지들의 시간순서가 올바르지 않습니다. 확인해주세요.');
+        alert('정류장들의 시간순서가 올바르지 않습니다. 확인해주세요.');
     }
   };
 
@@ -220,7 +220,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
           <br />
           경유지는 시간순서대로 입력해주세요.
           <br />
-          경유지는 거점지들 중 선택 가능합니다.
+          경유지는 장소들 중 선택 가능합니다.
         </Callout>
         <section className="pb-12">
           <Heading.h5 backgroundColor="yellow">
@@ -248,7 +248,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                   <h5 className="my-auto text-16 font-500">{index + 1}</h5>
                   <div className="w-[1px] rounded-full bg-grey-100" />
                   <div className="flex flex-col">
-                    <label className="text-16 font-500">거점지</label>
+                    <label className="text-16 font-500">정류장</label>
                     <Controller
                       control={control}
                       name={`shuttleRouteHubsToDestination.${index}` as const}
@@ -352,7 +352,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                   <h5 className="my-auto text-16 font-500">{index + 1}</h5>
                   <div className="w-[1px] rounded-full bg-grey-100" />
                   <div className="flex flex-col">
-                    <label className="text-16 font-500">거점지</label>
+                    <label className="text-16 font-500">정류장</label>
                     <Controller
                       control={control}
                       name={`shuttleRouteHubsFromDestination.${index}` as const}

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -170,7 +170,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
         error instanceof Error &&
         error.message === 'arrivalTime is not validated'
       )
-        alert('거점지들의 시간순서가 올바르지 않습니다. 확인해주세요.');
+        alert('정류장들의 시간순서가 올바르지 않습니다. 확인해주세요.');
     }
   };
 
@@ -382,7 +382,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
             <br />
             경유지는 시간순서대로 입력해주세요.
             <br />
-            경유지는 거점지들 중 선택 가능합니다.
+            경유지는 장소들 중 선택 가능합니다.
           </Callout>
           <section className="pb-12">
             <Heading.h5 backgroundColor="yellow">
@@ -411,7 +411,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                     <h5 className="my-auto text-16 font-500">{index + 1}</h5>
                     <div className="w-[1px] rounded-full bg-grey-100" />
                     <div className="flex flex-col">
-                      <label className="text-16 font-500">거점지</label>
+                      <label className="text-16 font-500">정류장</label>
                       <Controller
                         control={control}
                         name={`shuttleRouteHubsToDestination.${index}` as const}
@@ -521,7 +521,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                     <h5 className="my-auto text-16 font-500">{index + 1}</h5>
                     <div className="w-[1px] rounded-full bg-grey-100" />
                     <div className="flex flex-col">
-                      <label className="text-16 font-500">거점지</label>
+                      <label className="text-16 font-500">정류장</label>
                       <Controller
                         control={control}
                         name={

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -39,7 +39,7 @@ const EditHubPage = ({
 
   return (
     <>
-      <Heading>거점지 수정</Heading>
+      <Heading>장소 수정하기</Heading>
       {(isRegionsPending || isHubPending) && <div>Loading...</div>}
       {(isRegionsError || isHubError) && (
         <div>Error: {regionsError?.message || hubError?.message}</div>
@@ -88,11 +88,11 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
 
   const { mutate: putHub } = usePutRegionHub({
     onSuccess: () => {
-      alert('거점지가 수정되었습니다.');
+      alert('장소가 수정되었습니다.');
       router.push('/locations');
     },
     onError: (error) => {
-      alert(`거점지 수정에 실패했습니다.`);
+      alert(`장소 수정에 실패했습니다.`);
       console.error(error);
     },
   });
@@ -102,8 +102,8 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
       const target = regions?.find((r) => r.regionId === data.regionId);
       const confirmMessage =
         recommended?.regionId === data.regionId || false
-          ? `거점지를 수정하시겠습니까?`
-          : `선택한 주소 "${data.coord.address}"가 지역 "${target ? `${target.provinceFullName} ${target.cityFullName}` : '<오류: 알수 없는 위치>'}에 등록됩니다. 거점지를 수정하시겠습니까?`;
+          ? `장소를 수정하시겠습니까?`
+          : `선택한 주소 "${data.coord.address}"가 지역 "${target ? `${target.provinceFullName} ${target.cityFullName}` : '<오류: 알수 없는 위치>'}에 등록됩니다. 장소를 수정하시겠습니까?`;
       if (confirm(confirmMessage)) {
         putHub({
           regionId: data.regionId,
@@ -119,7 +119,7 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
     <main>
       <Form onSubmit={handleSubmit(onSubmit)} method="post">
         <Form.section>
-          <Form.label required>거점지 이름</Form.label>
+          <Form.label required>장소 이름</Form.label>
           <Controller
             control={control}
             name={`name`}

--- a/src/app/locations/components/RegionHubFilter.tsx
+++ b/src/app/locations/components/RegionHubFilter.tsx
@@ -47,7 +47,7 @@ const RegionHubFilter = ({ option, dispatch }: Props) => {
             />
           </article>
           <article>
-            <Label>거점지 이름</Label>
+            <Label>장소 이름</Label>
             <DebouncedInput
               value={option.name ?? ''}
               setValue={(value) =>

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -45,11 +45,11 @@ const NewHubPage = () => {
 
   const { mutate: addHub } = usePostRegionHub({
     onSuccess: () => {
-      alert('거점지가 추가되었습니다.');
+      alert('장소가 추가되었습니다.');
       router.push('/locations');
     },
     onError: (error) => {
-      alert(`거점지 추가에 실패했습니다.`);
+      alert(`장소 추가에 실패했습니다.`);
       console.error(error);
     },
   });
@@ -59,8 +59,8 @@ const NewHubPage = () => {
       const target = regions?.find((r) => r.regionId === data.regionId);
       const confirmMessage =
         recommended?.regionId === data.regionId || false
-          ? `거점지를 추가하시겠습니까?`
-          : `선택한 주소 "${data.coord.address}"가 지역 "${target ? `${target.provinceFullName} ${target.cityFullName}` : '<오류: 알수 없는 위치>'}에 등록됩니다. 거점지를 추가하시겠습니까?`;
+          ? `장소를 추가하시겠습니까?`
+          : `선택한 주소 "${data.coord.address}"가 지역 "${target ? `${target.provinceFullName} ${target.cityFullName}` : '<오류: 알수 없는 위치>'}에 등록됩니다. 장소를 추가하시겠습니까?`;
       if (confirm(confirmMessage)) {
         addHub({ regionId: data.regionId, body: conform(data) });
       }
@@ -70,10 +70,10 @@ const NewHubPage = () => {
 
   return (
     <main>
-      <Heading>거점지 추가</Heading>
+      <Heading>장소 추가</Heading>
       <Form onSubmit={handleSubmit(onSubmit)} method="post">
         <Form.section>
-          <Form.label required>거점지 이름</Form.label>
+          <Form.label required>장소 이름</Form.label>
           <Controller
             control={control}
             name={`name`}

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -35,7 +35,7 @@ const Page = () => {
   return (
     <main>
       <Heading className="flex items-baseline gap-20">
-        거점지 대시보드
+        장소 대시보드
         <BlueLink href="/locations/new" className="text-14">
           추가하기
         </BlueLink>

--- a/src/components/input/HubInput.tsx
+++ b/src/components/input/HubInput.tsx
@@ -82,8 +82,8 @@ const RegionHubInput = ({ regionId, value, setValue }: Props) => {
               : isLoading
                 ? '로딩 중…'
                 : regionHubs?.length === 0
-                  ? '거점지가 없습니다'
-                  : '거점지 선택'
+                  ? '장소가 없습니다'
+                  : '장소 선택'
           }
           defaultValue={null}
           displayValue={(hub: null | RegionHub) => hub?.name ?? ''}

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -3,26 +3,146 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
+interface RouteConfig {
+  path: string;
+  name: string;
+  parent?: string;
+}
+
+const ROUTES: RouteConfig[] = [
+  // 유저 관리
+  { path: '/users', name: '유저 대시보드' },
+  { path: '/users/:id', name: '유저 상세 페이지', parent: '/users/:id' },
+  // 행사 관리
+  { path: '/events', name: '행사 대시보드' },
+  { path: '/events/new', name: '행사 추가하기', parent: '/events' },
+  { path: '/events/:id/edit', name: '행사 수정하기', parent: '/events' },
+  {
+    path: '/events/:id/dates/:id',
+    name: '일자별 행사 상세 정보',
+    parent: '/events',
+  },
+  {
+    path: '/events/:id/dates/:id/demands',
+    name: '수요조사 대시보드',
+    parent: '/events',
+  },
+  {
+    path: '/events/:id/dates/:id/routes/:id',
+    name: '노선 정보',
+    parent: '/events/:id/dates/:id',
+  },
+  {
+    path: '/events/:id/dates/:id/routes/:id/reservations',
+    name: '노선별 예약 관리',
+    parent: '/events/:id/dates/:id',
+  },
+  {
+    path: '/events/:id/dates/:id/routes/new',
+    name: '노선 추가하기',
+    parent: '/events/:id/dates/:id',
+  },
+  {
+    path: '/events/:id/dates/:id/routes/:id/edit',
+    name: '노선 수정하기',
+    parent: '/events/:id/dates/:id/routes/:id',
+  },
+  // 예약 관리
+  { path: '/reservations', name: '예약 대시보드' },
+  {
+    path: '/reservations/:id',
+    name: '예약 상세 정보',
+    parent: '/reservations',
+  },
+  // 장소 관리
+  { path: '/locations', name: '장소 대시보드' },
+  { path: '/locations/new', name: '장소 추가하기', parent: '/locations' },
+  {
+    path: '/locations/:id/hubs/:id/edit',
+    name: '장소 수정하기',
+    parent: '/locations',
+  },
+  // 쿠폰 관리
+  { path: '/coupons', name: '쿠폰 대시보드' },
+  { path: '/coupons/new', name: '쿠폰 추가하기', parent: '/coupons' },
+  // 아티스트 관리
+  { path: '/artists', name: '아티스트 대시보드' },
+  { path: '/artists/new', name: '아티스트 추가하기', parent: '/artists' },
+];
+
 const Breadcrumbs = () => {
   const pathname = usePathname();
-  const pathnames = pathname.split('/').filter((x) => x);
+
+  // 현재 경로를 정규화
+  const normalizePath = (path: string) => {
+    return path
+      .split('/')
+      .map((segment) =>
+        /^\d+$/.test(segment) ? ':' + segment.replace(/\d+/, 'id') : segment,
+      )
+      .join('/');
+  };
+
+  // 브레드크럼 경로 생성
+  const getBreadcrumbs = (currentPath: string): RouteConfig[] => {
+    const normalizedPath = normalizePath(currentPath);
+
+    const currentRoute = ROUTES.find(
+      (route) => normalizePath(route.path) === normalizedPath,
+    );
+
+    if (!currentRoute) {
+      return [];
+    }
+
+    const breadcrumbs: RouteConfig[] = [currentRoute];
+    let parent = currentRoute.parent;
+
+    while (parent) {
+      const parentRoute = ROUTES.find((route) => route.path === parent);
+      if (parentRoute) {
+        breadcrumbs.unshift(parentRoute);
+        parent = parentRoute.parent;
+      } else {
+        break;
+      }
+    }
+
+    return breadcrumbs;
+  };
+
+  // 정규화 된 경로를 실제 경로로 변환
+  const generateActualPath = (normalizedPath: string) => {
+    const pathSegments = pathname.split('/');
+    return normalizedPath
+      .split('/')
+      .map((segment, index) =>
+        segment.startsWith(':') ? pathSegments[index] : segment,
+      )
+      .join('/');
+  };
+
+  const breadcrumbs = getBreadcrumbs(pathname);
 
   return (
     <div className="flex shrink-0 items-center gap-4 text-12 text-grey-600">
-      <Link href="/" className="underline">
-        Home
-      </Link>
-      {pathnames.map((value, index) => {
-        const to = `/${pathnames.slice(0, index + 1).join('/')}`;
-        return (
-          <span key={to}>
-            {' > '}
-            <Link href={to} className="underline">
-              {value}
+      {breadcrumbs.map((route, index) => (
+        <>
+          <span key={route.path}>
+            <Link
+              href={generateActualPath(route.path)}
+              className="underline underline-offset-2"
+            >
+              {route.name}
             </Link>
           </span>
-        );
-      })}
+          {index !== breadcrumbs.length - 1 && (
+            <span key={index} className="text-grey-600">
+              &gt;
+            </span>
+          )}
+        </>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## 개요

breadcrumb를 고도화 하여 현재 경로에 올바른 페이지 목록들이 이름과 함께 보여지도록 했습니다.

## 변경사항

<img width="394" alt="스크린샷 2025-02-14 오전 11 23 38" src="https://github.com/user-attachments/assets/3e3581ec-0ae6-4d86-9aab-15670f803bd3" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).