### PR TITLE
fix: 기타 수요조사 결과가 아래에 배치되도록 수정

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/components/Table.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/components/Table.tsx
@@ -73,11 +73,26 @@ const Table = ({ eventId, dailyEventId }: Props) => {
     });
 
     const sortedDemand = newDemand.sort((a, b) => {
+      const isACustom = !Boolean(a?.regionHubId);
+      const isBCustom = !Boolean(b?.regionHubId);
+
+      if (isACustom && isBCustom) {
+        return a?.regionHubName?.localeCompare(b?.regionHubName ?? '') ?? 0;
+      }
+      if (isACustom) {
+        return 1;
+      }
+      if (isBCustom) {
+        return -1;
+      }
+
       const aCount =
         a.fromDestinationCount + a.toDestinationCount + a.roundTripCount;
       const bCount =
         b.fromDestinationCount + b.toDestinationCount + b.roundTripCount;
-      return bCount - aCount;
+      return bCount - aCount === 0
+        ? (a?.regionHubName?.localeCompare(b?.regionHubName ?? '') ?? 0)
+        : bCount - aCount;
     });
 
     return sortedDemand;

--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/table.type.tsx
@@ -10,9 +10,10 @@ export const columns = [
       const isCustom = Boolean(!info.row.original?.regionHubId);
       const name = info.getValue();
       return (
-        <span className={`${isCustom && 'text-green-500'}`}>
-          {name} {isCustom && '(기타)'}
-        </span>
+        <p className={`flex gap-12 ${isCustom && 'text-green-500'}`}>
+          {isCustom && <span className="opacity-70">기타</span>}
+          {name}
+        </p>
       );
     },
   }),


### PR DESCRIPTION
## 개요

기타 수요조사 결과가 하단에 모여서 배치되도록 수정했습니다.

## 변경사항

<img width="1404" alt="스크린샷 2025-02-18 오후 3 24 33" src="https://github.com/user-attachments/assets/3273139f-3021-49f9-8299-ce09c0e89e72" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).