### PR TITLE
design: 행사 수요조사 링크 텍스트에 수 표시

### DIFF
--- a/src/app/events/table.type.tsx
+++ b/src/app/events/table.type.tsx
@@ -111,13 +111,16 @@ export const columns = [
   columnHelper.accessor(
     (row) => row.dailyEvents.map((dailyEvent) => dailyEvent.dailyEventId),
     {
-      header: '수요조사 상세',
+      header: '수요조사',
       cell: (info) => {
         const dailyEventIds = info.getValue();
         const eventId = info.row.original.eventId;
+        const totalCounts = info.row.original.dailyEvents.map((dailyEvent) => {
+          return dailyEvent.totalDemandCount;
+        });
         return (
           <div className="flex h-full flex-col justify-between">
-            {dailyEventIds.map((dailyEventId) => (
+            {dailyEventIds.map((dailyEventId, index) => (
               <p
                 key={dailyEventId}
                 className="flex h-[58px] grow items-center justify-center whitespace-nowrap break-keep border-b border-grey-200 px-8 last:border-b-0"
@@ -125,7 +128,7 @@ export const columns = [
                 <BlueLink
                   href={`/events/${eventId}/dates/${dailyEventId}/demands`}
                 >
-                  수요조사 보기
+                  상세 ({totalCounts[index]})
                 </BlueLink>
               </p>
             ))}


### PR DESCRIPTION
## 개요

행사 수요조사 링크 텍스트에 수요조사 수가 표시되도록 했습니다.


## 변경사항

<img width="906" alt="스크린샷 2025-02-25 오후 3 13 57" src="https://github.com/user-attachments/assets/1075a54c-065b-4a9d-af6d-94f75154ceb9" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).