### PR TITLE
style: 네이밍 변경 가는편 오는편 및 순서 변경

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
@@ -216,7 +216,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
           파란색으로 표시된 경유지는 행사 장소 근처 경유지에 해당합니다. (ex.
           인스파이어 아레나)
           <br />
-          반드시 목적지행과 귀가행 마다 두개 이상의 경유지를 입력해주세요.
+          반드시 목적지행과 오는편 마다 두개 이상의 경유지를 입력해주세요.
           <br />
           경유지는 시간순서대로 입력해주세요.
           <br />
@@ -224,7 +224,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
         </Callout>
         <section className="pb-12">
           <Heading.h5 backgroundColor="yellow">
-            목적지행
+            가는편
             <button
               type="button"
               onClick={() =>
@@ -328,7 +328,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
         <section>
           <Heading.h5 backgroundColor="yellow">
-            귀가행
+            오는편
             <button
               type="button"
               onClick={() =>

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/page.tsx
@@ -87,14 +87,14 @@ const Page = ({ params: { eventId, dailyEventId, shuttleRouteId } }: Props) => {
                     <List.item title="얼리버드 예약 마감일">
                       {formatDateString(route.earlybirdDeadline)}
                     </List.item>
-                    <List.item title="귀가행 얼리버드 가격">
-                      {route.earlybirdPriceFromDestination?.toLocaleString()}
-                    </List.item>
-                    <List.item title="목적지행 얼리버드 가격">
-                      {route.earlybirdPriceToDestination?.toLocaleString()}
-                    </List.item>
                     <List.item title="왕복 얼리버드 가격">
                       {route.earlybirdPriceRoundTrip?.toLocaleString()}
+                    </List.item>
+                    <List.item title="오는편 얼리버드 가격">
+                      {route.earlybirdPriceFromDestination?.toLocaleString()}
+                    </List.item>
+                    <List.item title="가는편 얼리버드 가격">
+                      {route.earlybirdPriceToDestination?.toLocaleString()}
                     </List.item>
                   </>
                 )}
@@ -103,14 +103,14 @@ const Page = ({ params: { eventId, dailyEventId, shuttleRouteId } }: Props) => {
                 <List.item title="예약 마감일">
                   {formatDateString(route.reservationDeadline)}
                 </List.item>
-                <List.item title="귀가행 가격">
-                  {route.regularPriceFromDestination.toLocaleString()}
-                </List.item>
-                <List.item title="목적지행 가격">
-                  {route.regularPriceToDestination.toLocaleString()}
-                </List.item>
                 <List.item title="왕복 가격">
                   {route.regularPriceRoundTrip.toLocaleString()}
+                </List.item>
+                <List.item title="오는편 가격">
+                  {route.regularPriceFromDestination.toLocaleString()}
+                </List.item>
+                <List.item title="가는편 가격">
+                  {route.regularPriceToDestination.toLocaleString()}
                 </List.item>
               </List>
               <List className="grid-cols-[72px_1fr]">
@@ -122,12 +122,12 @@ const Page = ({ params: { eventId, dailyEventId, shuttleRouteId } }: Props) => {
           </Callout>
 
           <section className="flex flex-col">
-            <Heading.h2>경유지 - 목적지행</Heading.h2>
+            <Heading.h2>경유지 - 가는편</Heading.h2>
             <BaseTable table={toHubTable} />
           </section>
 
           <section className="flex flex-col">
-            <Heading.h2>경유지 - 귀가행</Heading.h2>
+            <Heading.h2>경유지 - 오는편</Heading.h2>
             <BaseTable table={fromHubTable} />
           </section>
 

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/reservations/components/BusTable.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/reservations/components/BusTable.tsx
@@ -415,7 +415,7 @@ const BusTable = ({ eventId, dailyEventId, shuttleRouteId }: Props) => {
                     backgroundColor="yellow"
                     className="flex items-center gap-12"
                   >
-                    <span> 귀가행</span>
+                    <span> 오는편</span>
                     <span className="ml-12 text-14 font-500 text-grey-500">
                       {`(${busWithSeat.fromDestinationFilledSeat}/${busWithSeat.maxSeat})`}
                     </span>

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -254,7 +254,19 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
               <div className="flex flex-col gap-12">
                 <div className="flex flex-col items-start gap-8">
                   <label className="block break-keep text-16 font-500">
-                    목적지행
+                    왕복
+                  </label>
+                  <Controller
+                    control={control}
+                    name="regularPrice.roundTrip"
+                    render={({ field: { onChange, value } }) => (
+                      <NumberInput value={value ?? 0} setValue={onChange} />
+                    )}
+                  />
+                </div>
+                <div className="flex flex-col items-start gap-8">
+                  <label className="block break-keep text-16 font-500">
+                    가는편
                   </label>
                   <Controller
                     control={control}
@@ -266,23 +278,11 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                 </div>
                 <div className="flex flex-col items-start gap-8">
                   <label className="block break-keep text-16 font-500">
-                    귀가행
+                    오는편
                   </label>
                   <Controller
                     control={control}
                     name="regularPrice.fromDestination"
-                    render={({ field: { onChange, value } }) => (
-                      <NumberInput value={value ?? 0} setValue={onChange} />
-                    )}
-                  />
-                </div>
-                <div className="flex flex-col items-start gap-8">
-                  <label className="block break-keep text-16 font-500">
-                    왕복
-                  </label>
-                  <Controller
-                    control={control}
-                    name="regularPrice.roundTrip"
                     render={({ field: { onChange, value } }) => (
                       <NumberInput value={value ?? 0} setValue={onChange} />
                     )}
@@ -316,7 +316,25 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
               <div className="flex flex-col gap-12">
                 <div className="flex flex-col items-start gap-8">
                   <label className="block break-keep text-16 font-500">
-                    목적지행
+                    왕복
+                    <span className="ml-4 text-14 text-blue-500">
+                      {discountPercent(
+                        watchRegularPrice.roundTrip,
+                        watchEarlybirdPrice.roundTrip,
+                      )}
+                    </span>
+                  </label>
+                  <Controller
+                    control={control}
+                    name="earlybirdPrice.roundTrip"
+                    render={({ field: { onChange, value } }) => (
+                      <NumberInput value={value ?? 0} setValue={onChange} />
+                    )}
+                  />
+                </div>
+                <div className="flex flex-col items-start gap-8">
+                  <label className="block break-keep text-16 font-500">
+                    가는편
                     <span className="ml-4 text-14 text-blue-500">
                       {discountPercent(
                         watchRegularPrice.toDestination,
@@ -334,7 +352,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                 </div>
                 <div className="flex flex-col items-start gap-8">
                   <label className="block break-keep text-16 font-500">
-                    귀가행
+                    오는편
                     <span className="ml-4 text-14 text-blue-500">
                       {discountPercent(
                         watchRegularPrice.fromDestination,
@@ -350,24 +368,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                     )}
                   />
                 </div>
-                <div className="flex flex-col items-start gap-8">
-                  <label className="block break-keep text-16 font-500">
-                    왕복
-                    <span className="ml-4 text-14 text-blue-500">
-                      {discountPercent(
-                        watchRegularPrice.roundTrip,
-                        watchEarlybirdPrice.roundTrip,
-                      )}
-                    </span>
-                  </label>
-                  <Controller
-                    control={control}
-                    name="earlybirdPrice.roundTrip"
-                    render={({ field: { onChange, value } }) => (
-                      <NumberInput value={value ?? 0} setValue={onChange} />
-                    )}
-                  />
-                </div>
               </div>
             </div>
           </article>
@@ -378,7 +378,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
             파란색으로 표시된 경유지는 행사 장소 근처 경유지에 해당합니다. (ex.
             인스파이어 아레나)
             <br />
-            반드시 목적지행과 귀가행 마다 두개 이상의 경유지를 입력해주세요.
+            반드시 목적지행과 오는편 마다 두개 이상의 경유지를 입력해주세요.
             <br />
             경유지는 시간순서대로 입력해주세요.
             <br />
@@ -386,7 +386,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
           </Callout>
           <section className="pb-12">
             <Heading.h5 backgroundColor="yellow">
-              목적지행
+              가는편
               <button
                 type="button"
                 onClick={() =>
@@ -489,7 +489,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
           </section>
           <section>
             <Heading.h5 backgroundColor="yellow" className="flex">
-              귀가행
+              오는편
               <button
                 type="button"
                 onClick={() =>

--- a/src/types/shuttleRoute.type.ts
+++ b/src/types/shuttleRoute.type.ts
@@ -4,8 +4,8 @@ import { EventsViewEntitySchema } from './event.type';
 // ----- ENUM -----
 
 export const TripTypeEnum = z.enum([
-  'TO_DESTINATION', // 목적지행
-  'FROM_DESTINATION', // 귀가행
+  'TO_DESTINATION', // 가는편
+  'FROM_DESTINATION', // 오는편
   'ROUND_TRIP', // 왕복행
 ]);
 export type TripType = z.infer<typeof TripTypeEnum>;

--- a/src/utils/stringifier.util.ts
+++ b/src/utils/stringifier.util.ts
@@ -128,9 +128,9 @@ const Stringifier = Object.freeze({
   tripType(v: TripType) {
     switch (v) {
       case 'TO_DESTINATION':
-        return '목적지행';
+        return '가는편';
       case 'FROM_DESTINATION':
-        return '귀가행';
+        return '오는편';
       case 'ROUND_TRIP':
         return '왕복';
     }


### PR DESCRIPTION
## 개요
어드민에서 목적지행, 귀가행 -> 가는편, 오는편으로 네이밍을 변경햇습니다.
노선 추가하기에서 가격 지정 순서를 가는편, 오는편, 왕복 -> 왕복 가는편 오는편 순서로 반영되었습니다.
<img width="1021" alt="Screenshot 2025-02-27 at 1 38 40 PM" src="https://github.com/user-attachments/assets/8ad06237-08f9-4153-a8c1-e016cc7f43fc" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).