### PR TITLE
feat: submit 시에 버튼 비활성화처리

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -5,7 +5,7 @@ import { type CreateShuttleRouteForm } from './form.type';
 import { useRouter } from 'next/navigation';
 import Input from '@/components/input/Input';
 import { RegionHubInputSelfContained } from '@/components/input/HubInput';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import DateInput from '@/components/input/DateInput';
 import DateTimeInput from '@/components/input/DateTimeInput';
 import {
@@ -102,6 +102,8 @@ interface FormProps extends Props {
 const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
   const { eventId, dailyEventId } = params;
   const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const {
     register,
     control,
@@ -147,6 +149,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
       alert(
         '오류가 발생했습니다.\n' + (error instanceof Error && error.message),
       );
+      setIsSubmitting(false);
     },
   });
 
@@ -158,6 +161,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     )
       return;
     try {
+      setIsSubmitting(true);
       const shuttleRouteHubs = conform(data);
       postRoute({
         eventId,
@@ -165,6 +169,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
         body: shuttleRouteHubs,
       });
     } catch (error) {
+      setIsSubmitting(false);
       if (
         error instanceof Error &&
         error.message === 'arrivalTime is not validated'
@@ -590,7 +595,9 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
             </ul>
           </section>
         </FormContainer.section>
-        <FormContainer.submitButton>추가하기</FormContainer.submitButton>
+        <FormContainer.submitButton disabled={isSubmitting}>
+          {isSubmitting ? '처리 중...' : '추가하기'}
+        </FormContainer.submitButton>
       </FormContainer>
     </main>
   );

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -30,6 +30,7 @@ const defaultValues = {
 
 const CreateEventForm = () => {
   const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { control, handleSubmit } = useForm<CreateEventFormData>({
     defaultValues,
@@ -69,12 +70,14 @@ const CreateEventForm = () => {
         '행사 추가에 실패했습니다, ' +
           (error instanceof Error && error.message),
       );
+      setIsSubmitting(false);
     },
   });
 
   const onSubmit = useCallback(
     (data: CreateEventFormData) => {
       if (confirm('행사를 추가하시겠습니까?')) {
+        setIsSubmitting(true);
         postEvent(conform(data));
       }
     },
@@ -265,7 +268,9 @@ const CreateEventForm = () => {
             ))}
           </div>
         </Form.section>
-        <Form.submitButton>추가하기</Form.submitButton>
+        <Form.submitButton disabled={isSubmitting}>
+          {isSubmitting ? '처리 중...' : '추가하기'}
+        </Form.submitButton>
       </Form>
       <NewArtistsModal
         isOpen={isArtistModalOpen}

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,4 +1,5 @@
 import {
+  ButtonHTMLAttributes,
   FormHTMLAttributes,
   LabelHTMLAttributes,
   PropsWithChildren,
@@ -70,11 +71,19 @@ const Label = ({
 
 Form.label = Label;
 
-const SubmitButton = ({ children }: PropsWithChildren) => {
+interface SubmitButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  disabled?: boolean;
+}
+
+const SubmitButton = ({
+  children,
+  ...props
+}: PropsWithChildren<SubmitButtonProps>) => {
   return (
     <button
       type="submit"
-      className="flex items-center justify-center gap-8 rounded-lg bg-blue-500 p-8 font-500 text-white hover:bg-blue-600"
+      className="flex items-center justify-center gap-8 rounded-lg bg-blue-500 p-8 font-500 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-grey-100 disabled:text-grey-500"
+      {...props}
     >
       {children}
     </button>


### PR DESCRIPTION
## 개요
이벤트 추가, 노선 추가 페이지에서 폼 submit 시에 submit button 을 비활성화 처리하였습니다.

SubmitButton 에서 PropsWithChildren 타입을 갖고 있던데 file change 처럼 저렇게 수정해서 사용하는것이 맞는걸까요? 낯설어서 여쭤봐요

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).