### PR TITLE
feat: 정류장 지도 표시 및 재검색 기능

### DIFF
--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -1,14 +1,26 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { twJoin } from 'tailwind-merge';
-import { BanIcon, Loader2Icon } from 'lucide-react';
+import { BanIcon, Loader2Icon, RotateCwIcon } from 'lucide-react';
 import KakaoMapScript from '../script/KakaoMapScript';
+import { useGetRegionHubsWithoutPagination } from '@/services/hub.service';
+import { REGION_TO_ID } from 'src/constants/regions';
 
 interface Props {
   coord: Coord;
   setCoord: (coord: Coord) => void;
 }
+
+interface StationData {
+  id: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+}
+
+// 상수로 초기 줌 레벨 정의
+const INITIAL_ZOOM_LEVEL = 4;
 
 const CoordInput = ({ coord, setCoord }: Props) => {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -17,6 +29,29 @@ const CoordInput = ({ coord, setCoord }: Props) => {
   const [error, setError] = useState<boolean>(false);
   const kakaoMapRef = useRef<kakao.maps.Map | null>(null);
   const markerRef = useRef<kakao.maps.Marker | null>(null);
+  const [currentRegion, setCurrentRegion] = useState<string>('');
+  const [currentRegionId, setCurrentRegionId] = useState<string | null>(null);
+  const markersRef = useRef<Map<string, kakao.maps.Marker>>(new Map());
+  const [showSearchButton, setShowSearchButton] = useState<boolean>(true);
+  const [lastSearchedRegionId, setLastSearchedRegionId] = useState<
+    string | null
+  >(null);
+
+  const { data: regionHubs } = useGetRegionHubsWithoutPagination({
+    regionId: currentRegionId ?? '',
+    enabled: !!currentRegionId,
+  });
+
+  const regionHubsData = useMemo(
+    () =>
+      regionHubs?.map((regionHub) => ({
+        id: regionHub.regionHubId,
+        name: regionHub.name,
+        latitude: regionHub.latitude,
+        longitude: regionHub.longitude,
+      })),
+    [regionHubs],
+  );
 
   const setCoordWithAddress = useCallback(
     (latLng: kakao.maps.LatLng) => {
@@ -66,6 +101,117 @@ const CoordInput = ({ coord, setCoord }: Props) => {
     }
   };
 
+  const createHubsMarkerImage = () => {
+    const imageSrc =
+      'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
+    return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(24, 35), {
+      offset: new kakao.maps.Point(12, 35),
+    });
+  };
+
+  // 여러 마커 표시 함수
+  const displayStations = (stationList: StationData[]) => {
+    if (!kakaoMapRef.current) return;
+
+    // 기존 마커 모두 제거가 필요할까?
+    // markersRef.current.forEach((marker) => marker.setMap(null));
+    // markersRef.current.clear();
+
+    // 새 마커 생성 및 표시
+    stationList.forEach((station) => {
+      const position = new kakao.maps.LatLng(
+        station.latitude,
+        station.longitude,
+      );
+      const marker = new kakao.maps.Marker({
+        map: kakaoMapRef.current ?? undefined,
+        position: position,
+        title: station.name,
+        image: createHubsMarkerImage(),
+      });
+
+      const customOverlay = new kakao.maps.CustomOverlay({
+        position: position,
+        content: `
+            <div style="
+              background: white; 
+              padding: 8px 12px;
+              border-radius: 8px; 
+              box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+              font-size: 13px;
+              font-weight: bold;
+              text-align: center;
+              position: relative;
+              bottom: 80px;
+              white-space: nowrap;
+            ">${station.name}</div>
+          `,
+        xAnchor: 0.5,
+        yAnchor: 0,
+      });
+
+      // 마우스오버시 정류장 이름표시
+      kakao.maps.event.addListener(marker, 'mouseover', function () {
+        customOverlay.setMap(kakaoMapRef.current);
+      });
+
+      kakao.maps.event.addListener(marker, 'mouseout', function () {
+        customOverlay.setMap(null);
+      });
+
+      markersRef.current.set(station.id, marker);
+    });
+  };
+
+  const getCurrentRegion = useCallback(async () => {
+    if (!kakaoMapRef.current) return '';
+    // 현재 지도 중심점의 지역 정보만 가져오기
+    const center = kakaoMapRef.current.getCenter();
+
+    try {
+      const address = await toAddress(center.getLat(), center.getLng());
+      const addressParts = address.split(' ');
+
+      if (addressParts.length >= 2) {
+        const bigRegion = standardizeRegionName(addressParts[0]);
+        const smallRegion = addressParts[1];
+        const region = `${bigRegion} ${smallRegion}`;
+
+        setCurrentRegion(region);
+
+        const regionId = findRegionId(bigRegion, smallRegion);
+        setCurrentRegionId(typeof regionId === 'string' ? regionId : null);
+
+        console.log('현재 지역:', region, '지역 ID:', regionId);
+        return region;
+      }
+      return '';
+    } catch (error) {
+      console.error('지역 정보를 가져오는 데 실패했습니다.', error);
+      return '';
+    }
+  }, [findRegionId]);
+
+  // 지역 재검색 버튼 클릭 함수
+  const searchCurrentRegion = useCallback(async () => {
+    try {
+      await getCurrentRegion();
+
+      if (!currentRegionId) {
+        console.warn('지역 정보를 찾을 수 없거나 지원되지 않는 지역입니다.');
+        return;
+      }
+
+      setShowSearchButton(false);
+      displayStations(regionHubsData ?? []);
+      setLastSearchedRegionId(currentRegionId);
+    } catch (error) {
+      console.error('정류장 데이터를 불러오는 데 실패했습니다.', error);
+      setError(true);
+    }
+  }, [currentRegionId, getCurrentRegion, regionHubsData]);
+
+  // 지도 초기화 시 정류장 데이터도 함께 불러오기
   const initializeMap = useCallback(() => {
     try {
       if (window.kakao && mapRef.current) {
@@ -74,11 +220,13 @@ const CoordInput = ({ coord, setCoord }: Props) => {
             coord.latitude || 37.574187,
             coord.longitude || 126.976882,
           ),
-          level: 4,
+          level: INITIAL_ZOOM_LEVEL,
         };
 
         const map = new window.kakao.maps.Map(mapRef.current, options);
         kakaoMapRef.current = map;
+
+        // 개별 클릭 위치 표시용 마커
         const marker = new kakao.maps.Marker({
           position: map.getCenter(),
         });
@@ -90,6 +238,47 @@ const CoordInput = ({ coord, setCoord }: Props) => {
           'click',
           function (mouseEvent: kakao.maps.event.MouseEvent) {
             setCoordWithAddress(mouseEvent.latLng);
+          },
+        );
+
+        window.kakao.maps.event.addListener(map, 'dragend', async function () {
+          if (map) {
+            const center = map.getCenter();
+            try {
+              const address = await toAddress(center.getLat(), center.getLng());
+              const addressParts = address.split(' ');
+              if (addressParts.length >= 2) {
+                const region = addressParts.slice(0, 2).join(' ');
+                console.log('현재 지역:', region);
+                getCurrentRegion();
+              }
+            } catch (error) {
+              console.error('지역 정보를 가져오는 데 실패했습니다.', error);
+            }
+          }
+        });
+
+        window.kakao.maps.event.addListener(
+          map,
+          'zoom_changed',
+          async function () {
+            if (map) {
+              const center = map.getCenter();
+              try {
+                const address = await toAddress(
+                  center.getLat(),
+                  center.getLng(),
+                );
+                const addressParts = address.split(' ');
+                if (addressParts.length >= 2) {
+                  const region = addressParts.slice(0, 2).join(' ');
+                  console.log('현재 지역:', region);
+                  getCurrentRegion();
+                }
+              } catch (error) {
+                console.error('지역 정보를 가져오는 데 실패했습니다.', error);
+              }
+            }
           },
         );
 
@@ -106,12 +295,20 @@ const CoordInput = ({ coord, setCoord }: Props) => {
             ps.keywordSearch(target.value, setBoundOnSearch);
           });
         }
+
+        getCurrentRegion();
       }
     } catch (error) {
       setError(true);
       alert('지도를 불러오는 중 오류가 발생했습니다. \n' + error);
     }
-  }, []);
+  }, [coord.latitude, coord.longitude, getCurrentRegion, setCoordWithAddress]);
+
+  useEffect(() => {
+    if (currentRegionId !== lastSearchedRegionId) {
+      setShowSearchButton(true);
+    }
+  }, [currentRegionId, lastSearchedRegionId]);
 
   return (
     <>
@@ -157,6 +354,18 @@ const CoordInput = ({ coord, setCoord }: Props) => {
             오류가 발생하여 데이터 정합성을 위해 작동을 중지합니다. 새로고침
             해주세요.
           </div>
+          {showSearchButton && (
+            <div className="absolute bottom-12 left-1/2 z-10 -translate-x-1/2 transform">
+              <button
+                type="button"
+                onClick={searchCurrentRegion}
+                className="flex items-center gap-8 rounded-full bg-blue-400 px-16 py-8 text-white shadow-lg hover:bg-blue-300"
+              >
+                <RotateCwIcon />이 지역 재검색하기{' '}
+                {currentRegion ? `(${currentRegion})` : ''}
+              </button>
+            </div>
+          )}
         </div>
         <div>
           좌표: {coord.latitude}, {coord.longitude}
@@ -199,3 +408,48 @@ const toAddress = async (latitude: number, longitude: number) =>
 
     geocoder.coord2Address(coord.getLng(), coord.getLat(), callback);
   });
+
+const standardizeRegionName = (regionName: string): string => {
+  if (regionName === '서울') return '서울특별시';
+
+  if (
+    ['부산', '울산', '광주', '대전', '대구', '인천', '세종'].includes(
+      regionName,
+    )
+  ) {
+    if (regionName === '세종') return '세종특별자치시';
+    return `${regionName}광역시`;
+  }
+
+  if (['경기', '강원', '전북', '제주'].includes(regionName)) {
+    if (regionName === '제주') return '제주특별자치도';
+    if (regionName === '전북') return '전북특별자치도';
+    return `${regionName}도`;
+  }
+
+  if (regionName === '충북') return '충청북도';
+  if (regionName === '충남') return '충청남도';
+
+  if (regionName === '경북') return '경상북도';
+  if (regionName === '경남') return '경상남도';
+
+  if (regionName === '전남') return '전라남도';
+
+  return regionName;
+};
+
+const findRegionId = (
+  bigRegion: string,
+  smallRegion: string,
+): string | null => {
+  if (!bigRegion || !smallRegion) return null;
+
+  const regionId = REGION_TO_ID[bigRegion][smallRegion];
+
+  if (regionId) {
+    console.log('찾은 regionId:', regionId);
+    return regionId;
+  }
+
+  return null;
+};

--- a/src/services/hub.service.ts
+++ b/src/services/hub.service.ts
@@ -45,6 +45,30 @@ export interface GetRegionHubsOptionsWithPagination
   limit?: number;
 }
 
+export const getRegionHubsWithoutPagination = async (regionId: string) => {
+  const res = await authInstance.get(
+    `/v2/location/admin/regions/${regionId}/hubs`,
+    {
+      shape: withPagination({ regionHubs: RegionHubSchema.array() }),
+    },
+  );
+  return res.regionHubs;
+};
+
+export const useGetRegionHubsWithoutPagination = ({
+  regionId,
+  enabled,
+}: {
+  regionId: string;
+  enabled?: boolean;
+}) => {
+  return useQuery({
+    queryKey: ['regionHub', regionId],
+    queryFn: () => getRegionHubsWithoutPagination(regionId),
+    enabled,
+  });
+};
+
 export const getRegionHubs = async (
   options?: GetRegionHubsOptionsWithPagination,
 ) => {

--- a/src/types/region.type.ts
+++ b/src/types/region.type.ts
@@ -7,8 +7,8 @@ export const RegionSchema = z.object({
   cityFullName: z.string(),
   cityShortName: z.string(),
   relatedRegionIds: z.string().array(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
 });
 export type Region = z.infer<typeof RegionSchema>;
 


### PR DESCRIPTION
## 개요
- 이 지역 재검색하기 버튼을 누르면 해당 지역(regionId)의 정류장들을 지도에 표시합니다.
- 다른 지역(regionId)로 지도를 움직이면 '이 지역 재검색하기' 버튼이 생깁니다.
- 네이버 지도와 달리 재검색하기를 누르면, 기존에 불러온 정보들은 사라지지 않습니다. (혹은 사라지는 것이 더욱 바람직하다면 사라지도록 할 수 있습니다.)

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).