### PR TITLE
feat: 추가 노선 개설 요청 조회

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routeDemand.util.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routeDemand.util.ts
@@ -1,0 +1,55 @@
+const SHUTTLE_ROUTE_DEMAND_KEY = 'shuttleRouteDemand';
+
+interface ShuttleRouteIdentifier {
+  eventId: string;
+  dailyEventId: string;
+  shuttleRouteId: string;
+}
+
+const createShuttleRouteDemandKey = ({
+  eventId,
+  dailyEventId,
+  shuttleRouteId,
+}: ShuttleRouteIdentifier) =>
+  `${SHUTTLE_ROUTE_DEMAND_KEY}-${eventId}-${dailyEventId}-${shuttleRouteId}`;
+
+export const getShuttleRouteDemand = ({
+  eventId,
+  dailyEventId,
+  shuttleRouteId,
+}: ShuttleRouteIdentifier) => {
+  const shuttleRouteDemandKey = createShuttleRouteDemandKey({
+    eventId,
+    dailyEventId,
+    shuttleRouteId,
+  });
+  const shuttleRouteDemand = localStorage.getItem(shuttleRouteDemandKey);
+  return shuttleRouteDemand !== null && shuttleRouteDemand !== undefined
+    ? Number(shuttleRouteDemand)
+    : null;
+};
+
+export const setShuttleRouteDemand = (
+  demand: number,
+  { eventId, dailyEventId, shuttleRouteId }: ShuttleRouteIdentifier,
+) => {
+  const shuttleRouteDemandKey = createShuttleRouteDemandKey({
+    eventId,
+    dailyEventId,
+    shuttleRouteId,
+  });
+  localStorage.setItem(shuttleRouteDemandKey, demand.toString());
+};
+
+export const removeShuttleRouteDemand = ({
+  eventId,
+  dailyEventId,
+  shuttleRouteId,
+}: ShuttleRouteIdentifier) => {
+  const shuttleRouteDemandKey = createShuttleRouteDemandKey({
+    eventId,
+    dailyEventId,
+    shuttleRouteId,
+  });
+  localStorage.removeItem(shuttleRouteDemandKey);
+};

--- a/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
@@ -4,6 +4,11 @@ import { createColumnHelper } from '@tanstack/react-table';
 import BlueLink from '@/components/link/BlueLink';
 import { ShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 import Stringifier from '@/utils/stringifier.util';
+import {
+  getShuttleRouteDemand,
+  removeShuttleRouteDemand,
+  setShuttleRouteDemand,
+} from './routeDemand.util';
 
 const columnHelper = createColumnHelper<ShuttleRoutesViewEntity>();
 
@@ -37,6 +42,53 @@ export const columns = [
         <span className={`${count === maxCount ? 'text-red-500' : ''}`}>
           ({count} / {maxCount})
         </span>
+      );
+    },
+  }),
+  columnHelper.accessor('createdAt', {
+    header: () => '추가 개설 요청',
+    cell: (props) => {
+      const savedValue = getShuttleRouteDemand({
+        eventId: props.row.original.eventId,
+        dailyEventId: props.row.original.dailyEventId,
+        shuttleRouteId: props.row.original.shuttleRouteId,
+      });
+      const handleSave = () => {
+        setShuttleRouteDemand(savedValue ?? 0, {
+          eventId: props.row.original.eventId,
+          dailyEventId: props.row.original.dailyEventId,
+          shuttleRouteId: props.row.original.shuttleRouteId,
+        });
+      };
+      const handleRemove = () => {
+        removeShuttleRouteDemand({
+          eventId: props.row.original.eventId,
+          dailyEventId: props.row.original.dailyEventId,
+          shuttleRouteId: props.row.original.shuttleRouteId,
+        });
+      };
+      return (
+        <div className="group relative text-center">
+          <p>
+            {1}{' '}
+            {savedValue !== null && (
+              <span className="ml-[2px] text-12 text-grey-500">
+                {savedValue}
+              </span>
+            )}
+          </p>
+          <div className="absolute -right-100 -top-8 hidden w-120 rounded-[4px] bg-black/70 p-8 text-grey-50 group-hover:block">
+            {savedValue !== null ? (
+              <p className="text-12">저장된 값: {savedValue}</p>
+            ) : (
+              <p className="text-12">저장된 값이 없습니다.</p>
+            )}
+            <section className="flex justify-center gap-4 text-12 text-grey-200 underline underline-offset-2">
+              <button onClick={handleSave}>저장하기</button>
+              <button onClick={handleRemove}>삭제하기</button>
+            </section>
+          </div>
+        </div>
       );
     },
   }),

--- a/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
@@ -16,6 +16,30 @@ export const columns = [
     header: () => '상태',
     cell: (info) => Stringifier.shuttleRouteStatus(info.getValue()),
   }),
+  columnHelper.accessor('toDestinationCount', {
+    header: () => '가는 편',
+    cell: (info) => {
+      const count = info.getValue();
+      const maxCount = info.row.original.maxPassengerCount;
+      return (
+        <span className={`${count === maxCount ? 'text-red-500' : ''}`}>
+          ({count} / {maxCount})
+        </span>
+      );
+    },
+  }),
+  columnHelper.accessor('fromDestinationCount', {
+    header: () => '오는 편',
+    cell: (info) => {
+      const count = info.getValue();
+      const maxCount = info.row.original.maxPassengerCount;
+      return (
+        <span className={`${count === maxCount ? 'text-red-500' : ''}`}>
+          ({count} / {maxCount})
+        </span>
+      );
+    },
+  }),
   columnHelper.display({
     id: 'reservation-detail',
     header: () => '예약 상세',

--- a/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
@@ -2,7 +2,7 @@
 
 import { createColumnHelper } from '@tanstack/react-table';
 import BlueLink from '@/components/link/BlueLink';
-import { ShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
+import { AdminShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 import Stringifier from '@/utils/stringifier.util';
 import {
   getShuttleRouteDemand,
@@ -10,7 +10,7 @@ import {
   setShuttleRouteDemand,
 } from './routeDemand.util';
 
-const columnHelper = createColumnHelper<ShuttleRoutesViewEntity>();
+const columnHelper = createColumnHelper<AdminShuttleRoutesViewEntity>();
 
 export const columns = [
   columnHelper.accessor('name', {
@@ -45,32 +45,33 @@ export const columns = [
       );
     },
   }),
-  columnHelper.accessor('createdAt', {
+  columnHelper.accessor('demandCount', {
     header: () => '추가 개설 요청',
-    cell: (props) => {
+    cell: (info) => {
+      const value = info.getValue();
       const savedValue = getShuttleRouteDemand({
-        eventId: props.row.original.eventId,
-        dailyEventId: props.row.original.dailyEventId,
-        shuttleRouteId: props.row.original.shuttleRouteId,
+        eventId: info.row.original.eventId,
+        dailyEventId: info.row.original.dailyEventId,
+        shuttleRouteId: info.row.original.shuttleRouteId,
       });
       const handleSave = () => {
         setShuttleRouteDemand(savedValue ?? 0, {
-          eventId: props.row.original.eventId,
-          dailyEventId: props.row.original.dailyEventId,
-          shuttleRouteId: props.row.original.shuttleRouteId,
+          eventId: info.row.original.eventId,
+          dailyEventId: info.row.original.dailyEventId,
+          shuttleRouteId: info.row.original.shuttleRouteId,
         });
       };
       const handleRemove = () => {
         removeShuttleRouteDemand({
-          eventId: props.row.original.eventId,
-          dailyEventId: props.row.original.dailyEventId,
-          shuttleRouteId: props.row.original.shuttleRouteId,
+          eventId: info.row.original.eventId,
+          dailyEventId: info.row.original.dailyEventId,
+          shuttleRouteId: info.row.original.shuttleRouteId,
         });
       };
       return (
         <div className="group relative text-center">
           <p>
-            {1}{' '}
+            {value}{' '}
             {savedValue !== null && (
               <span className="ml-[2px] text-12 text-grey-500">
                 {savedValue}

--- a/src/app/reservations/[reservationId]/types/route.table.type.ts
+++ b/src/app/reservations/[reservationId]/types/route.table.type.ts
@@ -1,9 +1,9 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { formatDateString } from '@/utils/date.util';
 import Stringifier from '@/utils/stringifier.util';
-import { ShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
+import { AdminShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 
-const columnHelper = createColumnHelper<ShuttleRoutesViewEntity>();
+const columnHelper = createColumnHelper<AdminShuttleRoutesViewEntity>();
 
 export const columns = [
   columnHelper.accessor('name', {

--- a/src/components/input/ShuttleRouteInput.tsx
+++ b/src/components/input/ShuttleRouteInput.tsx
@@ -11,7 +11,7 @@ import {
 import { filterByFuzzy } from '@/utils/fuzzy.util';
 import { ChevronDown } from 'lucide-react';
 import { useGetShuttleRoutesOfDailyEvent } from '@/services/shuttleRoute.service';
-import { ShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
+import { AdminShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 
 interface Props {
   eventId: string;
@@ -33,20 +33,20 @@ const ShuttleRouteInput = ({
     dailyEventId,
   );
 
-  const setSelectedRoute: (route: ShuttleRoutesViewEntity | null) => void =
+  const setSelectedRoute: (route: AdminShuttleRoutesViewEntity | null) => void =
     useCallback(
-      (route: ShuttleRoutesViewEntity | null) => {
+      (route: AdminShuttleRoutesViewEntity | null) => {
         setValue(route?.shuttleRouteId ?? null);
       },
       [setValue],
     );
 
-  const selectedRoute: ShuttleRoutesViewEntity | null = useMemo(
+  const selectedRoute: AdminShuttleRoutesViewEntity | null = useMemo(
     () => data?.find((ds) => ds.shuttleRouteId === value) || null,
     [data, value],
   );
 
-  const filtered: ShuttleRoutesViewEntity[] = useMemo(() => {
+  const filtered: AdminShuttleRoutesViewEntity[] = useMemo(() => {
     return query
       ? filterByFuzzy(data ?? [], query, (p) => p.name)
       : (data ?? []);
@@ -55,7 +55,7 @@ const ShuttleRouteInput = ({
   if (error) return <div>Failed to load artists</div>;
 
   return (
-    <Combobox<ShuttleRoutesViewEntity | null>
+    <Combobox<AdminShuttleRoutesViewEntity | null>
       immediate
       value={selectedRoute}
       onChange={setSelectedRoute}
@@ -76,7 +76,7 @@ const ShuttleRouteInput = ({
                 : '노선 선택'
           }
           defaultValue={null}
-          displayValue={(route: null | ShuttleRoutesViewEntity) =>
+          displayValue={(route: null | AdminShuttleRoutesViewEntity) =>
             route?.name ?? ''
           }
           onChange={(event) => setQuery(event.target.value)}

--- a/src/services/shuttleRoute.service.ts
+++ b/src/services/shuttleRoute.service.ts
@@ -2,7 +2,7 @@ import {
   CreateShuttleRouteRequest,
   CreateShuttleRouteRequestSchema,
   ShuttleRouteStatus,
-  ShuttleRoutesViewEntitySchema,
+  AdminShuttleRoutesViewEntitySchema,
   TripType,
 } from '@/types/shuttleRoute.type';
 import { authInstance } from './config';
@@ -38,7 +38,7 @@ export const getShuttleRoutesOfDailyEvent = async (
     `/v2/shuttle-operation/admin/events/${eventId}/dates/${dailyEventId}/routes${toSearchParamString({ ...options }, '?')}`,
     {
       shape: withPagination({
-        shuttleRoutes: ShuttleRoutesViewEntitySchema.array(),
+        shuttleRoutes: AdminShuttleRoutesViewEntitySchema.array(),
       }),
     },
   );
@@ -64,7 +64,7 @@ export const getShuttleRoutes = async (options?: GetShuttleRoutesOptions) => {
     `/v2/shuttle-operation/admin/events/all/dates/all/routes${toSearchParamString({ ...options }, '?')}`,
     {
       shape: withPagination({
-        shuttleRoutes: ShuttleRoutesViewEntitySchema.array(),
+        shuttleRoutes: AdminShuttleRoutesViewEntitySchema.array(),
       }),
     },
   );
@@ -80,7 +80,7 @@ export const getShuttleRoute = async (
     `/v2/shuttle-operation/admin/events/${eventId}/dates/${dailyEventId}/routes/${shuttleRouteId}`,
     {
       shape: {
-        shuttleRoute: ShuttleRoutesViewEntitySchema,
+        shuttleRoute: AdminShuttleRoutesViewEntitySchema,
       },
     },
   );

--- a/src/types/region.type.ts
+++ b/src/types/region.type.ts
@@ -7,8 +7,6 @@ export const RegionSchema = z.object({
   cityFullName: z.string(),
   cityShortName: z.string(),
   relatedRegionIds: z.string().array(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
 });
 export type Region = z.infer<typeof RegionSchema>;
 

--- a/src/types/reservation.type.ts
+++ b/src/types/reservation.type.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  ShuttleRoutesViewEntitySchema,
+  AdminShuttleRoutesViewEntitySchema,
   TripTypeEnum,
 } from './shuttleRoute.type';
 
@@ -54,7 +54,7 @@ export const ReservationViewEntitySchema = z
     paymentUpdatedAt: z.string().nullable(),
     shuttleBusId: z.string().nullable(),
     passengerCount: z.number().int(),
-    shuttleRoute: ShuttleRoutesViewEntitySchema,
+    shuttleRoute: AdminShuttleRoutesViewEntitySchema,
     createdAt: z.string(),
     updatedAt: z.string(),
     hasReview: z.boolean(),

--- a/src/types/shuttleRoute.type.ts
+++ b/src/types/shuttleRoute.type.ts
@@ -41,7 +41,7 @@ export type ShuttleRouteHubsInShuttleRoutesViewEntity = z.infer<
   typeof ShuttleRouteHubsInShuttleRoutesViewEntitySchema
 >;
 
-export const ShuttleRoutesViewEntitySchema = z
+export const AdminShuttleRoutesViewEntitySchema = z
   .object({
     shuttleRouteId: z.string(),
     eventId: z.string(),
@@ -66,13 +66,14 @@ export const ShuttleRoutesViewEntitySchema = z
       ShuttleRouteHubsInShuttleRoutesViewEntitySchema.array(),
     fromDestinationShuttleRouteHubs:
       ShuttleRouteHubsInShuttleRoutesViewEntitySchema.array(),
+    demandCount: z.number().int(),
     event: z.lazy(() => EventsViewEntitySchema),
     createdAt: z.string(),
     updatedAt: z.string(),
   })
   .strict();
-export type ShuttleRoutesViewEntity = z.infer<
-  typeof ShuttleRoutesViewEntitySchema
+export type AdminShuttleRoutesViewEntity = z.infer<
+  typeof AdminShuttleRoutesViewEntitySchema
 >;
 
 // ----- POST -----


### PR DESCRIPTION
## 개요

추가 노선 개설 요청 조회를 추가했습니다.
- 추가 노선을 개설한 시점의 요청 수를 기록할 수 있도록 저장 기능을 추가로 구현해두었습니다.
- 노선 좌석 예매 현황 열을 추가했습니다.

## 변경사항

<img width="903" alt="스크린샷 2025-03-10 오후 6 51 18" src="https://github.com/user-attachments/assets/f9a4bd94-86d5-44a2-91d6-e37b65ddebdf" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).