### PR TITLE
fix: 예약 탑승객 수에 취소한 예약 탑승객 수 합산

### DIFF
--- a/src/app/(home)/components/ReservationPassengerCountChart.tsx
+++ b/src/app/(home)/components/ReservationPassengerCountChart.tsx
@@ -28,7 +28,14 @@ const ReservationPassengerCountChart = ({ options }: Props) => {
 
   const parsedReservationPassengerCounts = reservationPassengerCounts?.map(
     (item, index) => ({
-      ...item,
+      intervalReservationPassengerCount:
+        item.intervalReservationPassengerCount +
+        (cancelledReservationPassengerCounts?.[index]
+          ?.intervalReservationPassengerCount ?? 0),
+      cumulativeReservationPassengerCount:
+        item.cumulativeReservationPassengerCount +
+        (cancelledReservationPassengerCounts?.[index]
+          ?.cumulativeReservationPassengerCount ?? 0),
       intervalCancelledReservationPassengerCount:
         cancelledReservationPassengerCounts?.[index]
           ?.intervalReservationPassengerCount,
@@ -56,7 +63,16 @@ const ReservationPassengerCountChart = ({ options }: Props) => {
         ];
 
   return (
-    <ChartBox title="예약 탑승객">
+    <ChartBox
+      title={
+        <>
+          <span className="keep-word shrink-0">예약 탑승객</span>
+          <span className="ml-[6px] line-clamp-1 text-12 font-400 text-grey-600">
+            예약 탑승객 수는 취소한 예약 탑승객 수를 포함합니다.
+          </span>
+        </>
+      }
+    >
       <CustomLineChart
         data={parsedReservationPassengerCounts ?? []}
         dataKey={dataKey}

--- a/src/components/chart/ChartBox.tsx
+++ b/src/components/chart/ChartBox.tsx
@@ -2,14 +2,14 @@ import { ReactNode } from 'react';
 import Heading from '../text/Heading';
 
 interface Props {
-  title: string;
+  title: ReactNode;
   children: ReactNode;
 }
 
 const ChartBox = ({ title, children }: Props) => {
   return (
     <article className="flex h-300 grow flex-col rounded-[4px] border border-grey-200 bg-white p-4">
-      <Heading.h4 className="text-14 font-600 text-grey-900">
+      <Heading.h4 className="flex items-baseline text-14 font-600 text-grey-900">
         {title}
       </Heading.h4>
       {children}


### PR DESCRIPTION
## 개요

예약 탑승객 수에 취소한 예약 탑승객 수가 합산되도록 수정했습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).