### PR TITLE
feat: 정류장 핀 로드 이슈 해결 및 기능 개선

### DIFF
--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -6,7 +6,7 @@ import { BanIcon, Loader2Icon } from 'lucide-react';
 import { useGetRegionHubs } from '@/services/hub.service';
 import { toAddress } from '@/utils/region.uitl';
 import KakaoMapScript from '@/components/script/KakaoMapScript';
-
+import { createOverlayHTML } from '../createOverlayHTML.util';
 interface HubData {
   id: string;
   name: string;
@@ -334,20 +334,3 @@ const HubsMap = () => {
 };
 
 export default HubsMap;
-
-export const createOverlayHTML = (title: string, subtitle?: string) => {
-  return `
-    <div style="
-      background: white; 
-      padding: 8px 12px;
-      border-radius: 8px; 
-      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-      font-size: 13px;
-      font-weight: bold;
-      text-align: center;
-      position: relative;
-      bottom: 95px;
-      white-space: nowrap;
-    ">${title}${subtitle ? `<br/>(${subtitle})` : ''}</div>
-  `;
-};

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -30,7 +30,7 @@ const MAP_CONSTANTS = {
 };
 
 const HubsMap = () => {
-  const [mapInitialized, setMapInitialized] = useState(false);
+  const [isScriptReady, setIsScriptReady] = useState(false);
   const [coord, setCoord] = useState<Coord>({
     latitude: MAP_CONSTANTS.DEFAULT_LAT,
     longitude: MAP_CONSTANTS.DEFAULT_LNG,
@@ -244,7 +244,6 @@ const HubsMap = () => {
 
         const map = new window.kakao.maps.Map(mapRef.current, options);
         kakaoMapRef.current = map;
-        setMapInitialized(true);
 
         const marker = new kakao.maps.Marker({
           position: map.getCenter(),
@@ -263,6 +262,8 @@ const HubsMap = () => {
         );
 
         setupSearch();
+
+        displayHubs(regionHubsData);
       }
     } catch (error) {
       setError(true);
@@ -274,19 +275,20 @@ const HubsMap = () => {
     setupClickMarker,
     handleMapClick,
     setupSearch,
+    regionHubsData,
   ]);
 
   useEffect(() => {
-    if (regionHubsData && mapInitialized) {
-      displayHubs(regionHubsData);
+    if (isScriptReady && regionHubsData) {
+      window.kakao.maps.load(initializeMap);
     }
-  }, [regionHubsData, mapInitialized]);
+  }, [regionHubsData, isScriptReady]);
 
   if (regionHubsError || regionHubsLoading) return null;
   return (
     <>
       <KakaoMapScript
-        onReady={() => window.kakao.maps.load(initializeMap)}
+        onReady={() => setIsScriptReady(true)}
         libraries={['services']}
       />
       <article className="relative h-[68vh] p-16 [&_div]:cursor-pointer">

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -15,13 +15,25 @@ interface HubData {
   regionId: string;
 }
 
-const INITIAL_ZOOM_LEVEL = 4;
+interface Coord {
+  latitude: number;
+  longitude: number;
+  address: string;
+}
+
+const MAP_CONSTANTS = {
+  INITIAL_ZOOM_LEVEL: 4,
+  DEFAULT_LAT: 37.574187,
+  DEFAULT_LNG: 126.976882,
+  HUB_MARKER_IMAGE_URL:
+    'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
+};
 
 const HubsMap = () => {
   const [mapInitialized, setMapInitialized] = useState(false);
   const [coord, setCoord] = useState<Coord>({
-    latitude: 37.574187,
-    longitude: 126.976882,
+    latitude: MAP_CONSTANTS.DEFAULT_LAT,
+    longitude: MAP_CONSTANTS.DEFAULT_LNG,
     address: '',
   });
   const mapRef = useRef<HTMLDivElement>(null);
@@ -48,6 +60,13 @@ const HubsMap = () => {
         })),
     [regionHubs],
   );
+
+  const createHubsMarkerImage = useCallback(() => {
+    const imageSrc = MAP_CONSTANTS.HUB_MARKER_IMAGE_URL;
+    return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(24, 35), {
+      offset: new kakao.maps.Point(12, 35),
+    });
+  }, []);
 
   const setCoordWithAddress = useCallback(
     (latLng: kakao.maps.LatLng) => {
@@ -97,22 +116,11 @@ const HubsMap = () => {
     }
   };
 
-  const createHubsMarkerImage = () => {
-    const imageSrc =
-      'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
-    return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(24, 35), {
-      offset: new kakao.maps.Point(12, 35),
-    });
-  };
-
-  // 여러 마커 표시 함수
-  const displayHubs = (hubList: HubData[]) => {
-    if (!kakaoMapRef.current) return;
-
-    hubList.forEach((hub) => {
+  const createHubMarkerWithOverlay = useCallback(
+    (map: kakao.maps.Map, hub: HubData) => {
       const position = new kakao.maps.LatLng(hub.latitude, hub.longitude);
       const marker = new kakao.maps.Marker({
-        map: kakaoMapRef.current ?? undefined,
+        map: map,
         position: position,
         title: hub.name,
         image: createHubsMarkerImage(),
@@ -120,30 +128,15 @@ const HubsMap = () => {
 
       const customOverlay = new kakao.maps.CustomOverlay({
         position: position,
-        content: `
-            <div style="
-              background: white; 
-              padding: 8px 12px;
-              border-radius: 8px; 
-              box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-              font-size: 13px;
-              font-weight: bold;
-              text-align: center;
-              position: relative;
-              bottom: 95px;
-              white-space: nowrap;
-            ">${hub.name}<br/>(클릭시 수정페이지로 이동)</div>
-          `,
+        content: createOverlayHTML(hub.name, '클릭시 수정페이지로 이동'),
         xAnchor: 0.5,
         yAnchor: 0,
       });
 
-      // 마우스오버시 정류장 이름표시
       kakao.maps.event.addListener(marker, 'mouseover', () => {
-        customOverlay.setMap(kakaoMapRef.current);
+        customOverlay.setMap(map);
       });
 
-      // 마커 직접 클릭 시 상세 페이지로 이동
       kakao.maps.event.addListener(marker, 'click', () => {
         window.open(
           `/locations/${hub.regionId}/hubs/${hub.id}/edit`,
@@ -155,106 +148,133 @@ const HubsMap = () => {
       kakao.maps.event.addListener(marker, 'mouseout', () => {
         customOverlay.setMap(null);
       });
-    });
-  };
+    },
+    [createHubsMarkerImage],
+  );
 
-  // 지도 초기화 시 정류장 데이터도 함께 불러오기
+  const displayHubs = useCallback(
+    (hubList: HubData[]) => {
+      if (!kakaoMapRef.current) return;
+
+      hubList.forEach((hub) => {
+        createHubMarkerWithOverlay(kakaoMapRef.current!, hub);
+      });
+    },
+    [createHubMarkerWithOverlay],
+  );
+
+  const setupClickMarker = useCallback(
+    (map: kakao.maps.Map, marker: kakao.maps.Marker) => {
+      const clickMarkerOverlay = new kakao.maps.CustomOverlay({
+        position: marker.getPosition(),
+        content: createOverlayHTML('이 위치로 정류장 생성하기', '핀 클릭'),
+        xAnchor: 0.5,
+        yAnchor: 0,
+      });
+
+      kakao.maps.event.addListener(marker, 'mouseover', () => {
+        clickMarkerOverlay.setMap(map);
+      });
+
+      kakao.maps.event.addListener(marker, 'mouseout', () => {
+        clickMarkerOverlay.setMap(null);
+      });
+
+      kakao.maps.event.addListener(marker, 'click', () => {
+        const position = marker.getPosition();
+        const latitude = position.getLat();
+        const longitude = position.getLng();
+        const address = toAddress(latitude, longitude);
+        window.open(
+          `/locations/new?latitude=${latitude}&longitude=${longitude}&address=${address}`,
+          '_blank',
+          'noopener',
+        );
+      });
+
+      return clickMarkerOverlay;
+    },
+    [],
+  );
+
+  const handleMapClick = useCallback(
+    (
+      map: kakao.maps.Map,
+      mouseEvent: kakao.maps.event.MouseEvent,
+      clickMarkerOverlay: kakao.maps.CustomOverlay,
+    ) => {
+      setCoordWithAddress(mouseEvent.latLng);
+      clickMarkerOverlay.setPosition(mouseEvent.latLng);
+
+      const currentLevel = map.getLevel();
+      if (currentLevel >= 6) {
+        map.setCenter(mouseEvent.latLng);
+        map.setLevel(currentLevel - 1);
+      }
+    },
+    [setCoordWithAddress],
+  );
+
+  const setupSearch = useCallback(() => {
+    const ps = new window.kakao.maps.services.Places();
+    const searchInput = document.getElementById('search-input');
+
+    if (searchInput) {
+      searchInput.addEventListener('keydown', (event: KeyboardEvent) => {
+        if (event.key !== 'Enter') {
+          return;
+        }
+        event.preventDefault();
+        const target = event.target as HTMLInputElement;
+        ps.keywordSearch(target.value, setBoundOnSearch);
+      });
+    }
+  }, [setBoundOnSearch]);
+
   const initializeMap = useCallback(() => {
     try {
       if (window.kakao && mapRef.current) {
         const options = {
           center: new window.kakao.maps.LatLng(
-            coord.latitude || 37.574187,
-            coord.longitude || 126.976882,
+            coord.latitude || MAP_CONSTANTS.DEFAULT_LAT,
+            coord.longitude || MAP_CONSTANTS.DEFAULT_LNG,
           ),
-          level: INITIAL_ZOOM_LEVEL,
+          level: MAP_CONSTANTS.INITIAL_ZOOM_LEVEL,
         };
 
         const map = new window.kakao.maps.Map(mapRef.current, options);
         kakaoMapRef.current = map;
         setMapInitialized(true);
 
-        // 개별 클릭 위치 표시용 마커
         const marker = new kakao.maps.Marker({
           position: map.getCenter(),
         });
         marker.setMap(map);
         markerRef.current = marker;
 
-        const clickMarkerOverlay = new kakao.maps.CustomOverlay({
-          position: marker.getPosition(),
-          content: `
-            <div style="
-              background: white; 
-              padding: 8px 12px;
-              border-radius: 8px; 
-              box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-              font-size: 13px;
-              font-weight: bold;
-              text-align: center;
-              position: relative;
-              bottom: 95px;
-              white-space: nowrap;
-            ">이 위치로 정류장 생성하기 (핀 클릭)</div>
-          `,
-          xAnchor: 0.5,
-          yAnchor: 0,
-        });
-
-        kakao.maps.event.addListener(marker, 'mouseover', () => {
-          clickMarkerOverlay.setMap(map);
-        });
-
-        kakao.maps.event.addListener(marker, 'mouseout', () => {
-          clickMarkerOverlay.setMap(null);
-        });
-
-        kakao.maps.event.addListener(marker, 'click', () => {
-          const position = marker.getPosition();
-          const latitude = position.getLat();
-          const longitude = position.getLng();
-          const address = toAddress(latitude, longitude);
-          window.open(
-            `/locations/new?latitude=${latitude}&longitude=${longitude}&address=${address}`,
-            '_blank',
-            'noopener',
-          );
-        });
+        const clickMarkerOverlay = setupClickMarker(map, marker);
 
         window.kakao.maps.event.addListener(
           map,
           'click',
           (mouseEvent: kakao.maps.event.MouseEvent) => {
-            setCoordWithAddress(mouseEvent.latLng);
-            clickMarkerOverlay.setPosition(mouseEvent.latLng);
-
-            const currentLevel = map.getLevel();
-            if (currentLevel >= 6) {
-              map.setCenter(mouseEvent.latLng);
-              map.setLevel(currentLevel - 1);
-            }
+            handleMapClick(map, mouseEvent, clickMarkerOverlay);
           },
         );
 
-        const ps = new window.kakao.maps.services.Places();
-
-        const searchInput = document.getElementById('search-input');
-        if (searchInput) {
-          searchInput.addEventListener('keydown', (event: KeyboardEvent) => {
-            if (event.key !== 'Enter') {
-              return;
-            }
-            event.preventDefault();
-            const target = event.target as HTMLInputElement;
-            ps.keywordSearch(target.value, setBoundOnSearch);
-          });
-        }
+        setupSearch();
       }
     } catch (error) {
       setError(true);
       alert('지도를 불러오는 중 오류가 발생했습니다. \n' + error);
     }
-  }, [coord.latitude, coord.longitude, setCoordWithAddress]);
+  }, [
+    coord.latitude,
+    coord.longitude,
+    setupClickMarker,
+    handleMapClick,
+    setupSearch,
+  ]);
 
   useEffect(() => {
     if (regionHubsData && mapInitialized) {
@@ -315,8 +335,19 @@ const HubsMap = () => {
 
 export default HubsMap;
 
-interface Coord {
-  latitude: number;
-  longitude: number;
-  address: string;
-}
+export const createOverlayHTML = (title: string, subtitle?: string) => {
+  return `
+    <div style="
+      background: white; 
+      padding: 8px 12px;
+      border-radius: 8px; 
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      font-size: 13px;
+      font-weight: bold;
+      text-align: center;
+      position: relative;
+      bottom: 95px;
+      white-space: nowrap;
+    ">${title}${subtitle ? `<br/>(${subtitle})` : ''}</div>
+  `;
+};

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -269,8 +269,8 @@ const HubsMap = () => {
         onReady={() => window.kakao.maps.load(initializeMap)}
         libraries={['services']}
       />
-      <article className="relative h-screen p-16 [&_div]:cursor-pointer">
-        <div className="relative h-5/6 rounded-[12px] transition-opacity">
+      <article className="relative h-[68vh] p-16 [&_div]:cursor-pointer">
+        <div className="relative h-full rounded-[12px] transition-opacity">
           <div
             ref={mapRef}
             className={twJoin(

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -18,6 +18,7 @@ interface HubData {
 const INITIAL_ZOOM_LEVEL = 4;
 
 const HubsMap = () => {
+  const [mapInitialized, setMapInitialized] = useState(false);
   const [coord, setCoord] = useState<Coord>({
     latitude: 37.574187,
     longitude: 126.976882,
@@ -171,6 +172,7 @@ const HubsMap = () => {
 
         const map = new window.kakao.maps.Map(mapRef.current, options);
         kakaoMapRef.current = map;
+        setMapInitialized(true);
 
         // 개별 클릭 위치 표시용 마커
         const marker = new kakao.maps.Marker({
@@ -214,10 +216,10 @@ const HubsMap = () => {
   }, [coord.latitude, coord.longitude, setCoordWithAddress]);
 
   useEffect(() => {
-    if (regionHubsData) {
+    if (regionHubsData && mapInitialized) {
       displayHubs(regionHubsData);
     }
-  }, [regionHubsData]);
+  }, [regionHubsData, mapInitialized]);
 
   if (regionHubsError || regionHubsLoading) return null;
   return (

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -186,9 +186,9 @@ const HubsMap = () => {
             setCoordWithAddress(mouseEvent.latLng);
 
             const currentLevel = map.getLevel();
-            if (currentLevel >= 5) {
+            if (currentLevel >= 6) {
               map.setCenter(mouseEvent.latLng);
-              map.setLevel(4);
+              map.setLevel(currentLevel - 1);
             }
           },
         );

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -181,11 +181,52 @@ const HubsMap = () => {
         marker.setMap(map);
         markerRef.current = marker;
 
+        const clickMarkerOverlay = new kakao.maps.CustomOverlay({
+          position: marker.getPosition(),
+          content: `
+            <div style="
+              background: white; 
+              padding: 8px 12px;
+              border-radius: 8px; 
+              box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+              font-size: 13px;
+              font-weight: bold;
+              text-align: center;
+              position: relative;
+              bottom: 95px;
+              white-space: nowrap;
+            ">이 위치로 정류장 생성하기 (핀 클릭)</div>
+          `,
+          xAnchor: 0.5,
+          yAnchor: 0,
+        });
+
+        kakao.maps.event.addListener(marker, 'mouseover', () => {
+          clickMarkerOverlay.setMap(map);
+        });
+
+        kakao.maps.event.addListener(marker, 'mouseout', () => {
+          clickMarkerOverlay.setMap(null);
+        });
+
+        kakao.maps.event.addListener(marker, 'click', () => {
+          const position = marker.getPosition();
+          const latitude = position.getLat();
+          const longitude = position.getLng();
+          const address = toAddress(latitude, longitude);
+          window.open(
+            `/locations/new?latitude=${latitude}&longitude=${longitude}&address=${address}`,
+            '_blank',
+            'noopener',
+          );
+        });
+
         window.kakao.maps.event.addListener(
           map,
           'click',
           (mouseEvent: kakao.maps.event.MouseEvent) => {
             setCoordWithAddress(mouseEvent.latLng);
+            clickMarkerOverlay.setPosition(mouseEvent.latLng);
 
             const currentLevel = map.getLevel();
             if (currentLevel >= 6) {

--- a/src/app/locations/map/createOverlayHTML.util.ts
+++ b/src/app/locations/map/createOverlayHTML.util.ts
@@ -1,0 +1,16 @@
+export const createOverlayHTML = (title: string, subtitle?: string) => {
+  return `
+    <div style="
+      background: white; 
+      padding: 8px 12px;
+      border-radius: 8px; 
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      font-size: 13px;
+      font-weight: bold;
+      text-align: center;
+      position: relative;
+      bottom: 95px;
+      white-space: nowrap;
+    ">${title}${subtitle ? `<br/>(${subtitle})` : ''}</div>
+  `;
+};

--- a/src/app/locations/map/page.tsx
+++ b/src/app/locations/map/page.tsx
@@ -21,7 +21,7 @@ const Page = () => {
           <li>3. 핀을 클릭하면 해당 정류장의 수정 페이지로 이동합니다.</li>
         </ul>
       </Callout>
-      <HubsMap />;
+      <HubsMap />
     </div>
   );
 };

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -13,19 +13,22 @@ import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
 
-const NewHubPage = () => {
+const NewHubPage = ({
+  searchParams,
+}: {
+  searchParams: { latitude: string; longitude: string; address: string };
+}) => {
   const router = useRouter();
 
   const { data: regions } = useGetRegions();
-
   const { control, handleSubmit } = useForm<CreateHubFormType>({
     defaultValues: {
       regionId: undefined,
       name: '',
       coord: {
-        address: '',
-        latitude: 0,
-        longitude: 0,
+        address: searchParams.address ?? '',
+        latitude: parseFloat(searchParams.latitude) ?? 0,
+        longitude: parseFloat(searchParams.longitude) ?? 0,
       },
     },
   });

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -223,9 +223,9 @@ const CoordInput = ({ coord, setCoord }: Props) => {
             setCoordWithAddress(mouseEvent.latLng);
 
             const currentLevel = map.getLevel();
-            if (currentLevel >= 5) {
+            if (currentLevel >= 6) {
               map.setCenter(mouseEvent.latLng);
-              map.setLevel(4);
+              map.setLevel(currentLevel - 1);
             }
           },
         );

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -23,6 +23,7 @@ interface HubData {
 const INITIAL_ZOOM_LEVEL = 4;
 
 const CoordInput = ({ coord, setCoord }: Props) => {
+  const [mapInitialized, setMapInitialized] = useState(false);
   const mapRef = useRef<HTMLDivElement>(null);
   const [hasRequestedSearch, setHasRequestedSearch] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
@@ -208,6 +209,7 @@ const CoordInput = ({ coord, setCoord }: Props) => {
 
         const map = new window.kakao.maps.Map(mapRef.current, options);
         kakaoMapRef.current = map;
+        setMapInitialized(true);
 
         // 개별 클릭 위치 표시용 마커
         const marker = new kakao.maps.Marker({
@@ -293,6 +295,15 @@ const CoordInput = ({ coord, setCoord }: Props) => {
       displayHubs(regionHubsData);
     }
   }, [regionHubsData]);
+
+  // 지도보기에서 핀을 클릭해서 새 정류장 만들기로 넘어온 경우 핀 위치 좌표 가져오기
+  useEffect(() => {
+    if (coord.latitude && coord.longitude && mapInitialized) {
+      setCoordWithAddress(
+        new window.kakao.maps.LatLng(coord.latitude, coord.longitude),
+      );
+    }
+  }, [mapInitialized, setCoordWithAddress]);
 
   return (
     <>


### PR DESCRIPTION
## 1. 첫 진입시 정류장 핀이 로드되지 않는 이슈 해결
문제 원인을 분석해보았습니다. 아래의 두가지 시나리오가 모두 생길 수 있어서 간헐적으로 일어나는 일이라고 판단했어요.

#### **정상작동 플로우**
1. 카카오맵 Script 가 로드가 완료되면 콜백함수인 () => initailizeMap() 을 실행함. -> 지도 초기화 완료.
2. get regionHubs 요청이 완료됨. -> 의존성을 걸어둔 useEffect에서 displayHubs() 호출 -> 정류장에 핀 성공적으로 그림.

#### **문제가 생기는 플로우**
*getRegionHubs API 요청이 비동기적으로 이루어짐.
1. (그래서 카카오맵 script 가 로드되기 전) get 요청이 완료되면 의존성을 걸어둔 useEffect에서 displayHubs를 호출 
-> 지도가 초기화 되지 않아 if (!kakaoMaps.current) return 문에 의해 함수 종료.
2. 카카오맵 Script 가 로드가 완료되면 콜백함수인 () => initailizeMap() 을 실행함. -> 지도 초기화 완료.
그러나 displayHubs를 다시 호출하지 않음. -> 정류장핀이 그려지지 않음.

### 해결방법
initailizeMap() 함수안에 mapInitialized 상태를 true로 둬서, 카카오맵 초기화 후 다시 displayHubs를 호출하도록 함.

## 2. 기능 개선
- (장소 공통) 줌레벨 5 이상에서 클릭시 줌 레벨 4로 변경 -> 줌 레벨 5이상에서 한번 클릭시 줌 레벨 -1
- (지도 보기) 지도 클릭시 생기는 파란색 핀을 클릭할 경우 해당 좌표를 반영해서 새 정류장 추가하기 새 창으로 열립니다.

## 3. 리팩토링
hubsMap.tsx 를 중복 코드 감소 및 가독성 개선을 목표로 리팩토링하였습니다. (customOverlay를 두군데에서 중복으로 사용하는 등..)
coordInput.tsx는 이후 PR 에서 함께 리팩토링 진행해볼게요. 

https://github.com/user-attachments/assets/341d8167-10e3-4808-a83c-5297977b090e

https://github.com/user-attachments/assets/0ae0270b-951e-44f3-9837-f32f3861b831



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).