### PR TITLE
feat: 노선 매출 정보 표시

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/table.type.tsx
@@ -4,8 +4,99 @@ import { createColumnHelper } from '@tanstack/react-table';
 import BlueLink from '@/components/link/BlueLink';
 import { formatDateString } from '@/utils/date.util';
 import { ShuttleBusesViewEntity } from '@/types/shuttleBus.type';
-import { ShuttleRouteHubsInShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
+import {
+  AdminShuttleRoutesViewEntity,
+  ShuttleRouteHubsInShuttleRoutesViewEntity,
+} from '@/types/shuttleRoute.type';
 import Stringifier from '@/utils/stringifier.util';
+
+type ExtendedAdminShuttleRoutesViewEntity = AdminShuttleRoutesViewEntity & {
+  totalSales: number;
+  totalSalesWithDiscount: number;
+};
+
+const shuttleRouteColumnHelper =
+  createColumnHelper<ExtendedAdminShuttleRoutesViewEntity>();
+
+export const shuttleRouteColumns = [
+  shuttleRouteColumnHelper.accessor('event.eventName', {
+    header: () => '행사명',
+    cell: (info) => info.getValue(),
+  }),
+  shuttleRouteColumnHelper.accessor('dailyEventId', {
+    header: () => '날짜',
+    cell: (info) => {
+      const dailyEvents = info.row.original.event.dailyEvents;
+      const dailyEvent = dailyEvents.find(
+        (dailyEvent) => dailyEvent.dailyEventId === info.getValue(),
+      );
+      return dailyEvent ? formatDateString(dailyEvent.date, 'date') : '-';
+    },
+  }),
+  shuttleRouteColumnHelper.accessor('name', {
+    header: () => '노선 이름',
+    cell: (info) => info.getValue(),
+  }),
+  shuttleRouteColumnHelper.accessor('reservationDeadline', {
+    header: () => '예약 마감일',
+    cell: (info) => formatDateString(info.getValue()),
+  }),
+  shuttleRouteColumnHelper.accessor('status', {
+    header: () => '상태',
+    cell: (info) => Stringifier.shuttleRouteStatus(info.getValue()),
+  }),
+  shuttleRouteColumnHelper.accessor('maxPassengerCount', {
+    header: () => '최대 승객 수',
+    cell: (info) => info.getValue(),
+  }),
+  shuttleRouteColumnHelper.accessor('regularPriceRoundTrip', {
+    header: () => '왕복 가격',
+    cell: (info) => info.getValue().toLocaleString(),
+  }),
+  shuttleRouteColumnHelper.accessor('regularPriceToDestination', {
+    header: () => '가는 편 가격',
+    cell: (info) => info.getValue().toLocaleString(),
+  }),
+  shuttleRouteColumnHelper.accessor('regularPriceFromDestination', {
+    header: () => '오는 편 가격',
+    cell: (info) => info.getValue().toLocaleString(),
+  }),
+  shuttleRouteColumnHelper.accessor('earlybirdDeadline', {
+    header: () => '얼리버드 마감일',
+    cell: (info) => {
+      const value = info.getValue();
+      return value ? formatDateString(value, 'datetime') : '-';
+    },
+  }),
+  shuttleRouteColumnHelper.accessor('earlybirdPriceToDestination', {
+    header: () => '얼리버드 가는 편 가격',
+    cell: (info) => {
+      const value = info.getValue();
+      return value ? value.toLocaleString() : '-';
+    },
+  }),
+  shuttleRouteColumnHelper.accessor('earlybirdPriceFromDestination', {
+    header: () => '얼리버드 오는 편 가격',
+    cell: (info) => {
+      const value = info.getValue();
+      return value ? value.toLocaleString() : '-';
+    },
+  }),
+  shuttleRouteColumnHelper.accessor('totalSales', {
+    header: () => '일반 매출',
+    cell: (info) => {
+      const value = info.getValue();
+      return value ? value.toLocaleString() : '-';
+    },
+  }),
+  shuttleRouteColumnHelper.accessor('totalSalesWithDiscount', {
+    header: () => '실제 매출',
+    cell: (info) => {
+      const value = info.getValue();
+      return value ? value.toLocaleString() : '-';
+    },
+  }),
+];
 
 type ExtendedShuttleBusesViewEntity = ShuttleBusesViewEntity & {
   eventId: string;

--- a/src/types/shuttleBus.type.ts
+++ b/src/types/shuttleBus.type.ts
@@ -31,7 +31,6 @@ export const ShuttleBusesViewEntitySchema = z
     openChatLink: z.string().nullable(),
   })
   .strict();
-
 export type ShuttleBusesViewEntity = z.infer<
   typeof ShuttleBusesViewEntitySchema
 >;

--- a/src/utils/date.util.ts
+++ b/src/utils/date.util.ts
@@ -1,6 +1,6 @@
 import dayjs, { Dayjs } from 'dayjs';
 
-export const formatDate = (date: Dayjs, type: 'date' | 'datetime' = 'date') => {
+const formatDate = (date: Dayjs, type: 'date' | 'datetime' = 'date') => {
   if (type === 'datetime') {
     return date.format('YYYY. MM. DD. HH:mm:ss');
   } else {


### PR DESCRIPTION
## 개요

노선 매출에 대한 정보가 노선 상세 페이지에서 표시되도록 수정했습니다.
또한 가독성 향상을 위해 기존에 Callout 안에 있던 정보들을 테이블 안으로 옮겼습니다.

## 변경사항

<img width="940" alt="스크린샷 2025-03-17 오후 2 22 00" src="https://github.com/user-attachments/assets/ff5f13c5-95d4-40fa-a700-30bed441c6b2" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).