### PR TITLE
feat(노선생성하기): 경로 소요시간 자동 계산하기

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/components/roundNearestFiveMinutes.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/components/roundNearestFiveMinutes.ts
@@ -1,0 +1,15 @@
+import { Dayjs } from 'dayjs';
+
+const roundUpToNearestFiveMinutes = (time: Dayjs) => {
+  const minutes = time.minute();
+  const roundedMinutes = Math.ceil(minutes / 5) * 5;
+  return time.add(roundedMinutes - minutes, 'minute');
+};
+
+const roundDownToNearestFiveMinutes = (time: Dayjs) => {
+  const minutes = time.minute();
+  const roundedMinutes = Math.floor(minutes / 5) * 5;
+  return time.subtract(minutes - roundedMinutes, 'minute');
+};
+
+export { roundUpToNearestFiveMinutes, roundDownToNearestFiveMinutes };

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/conform.util.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/conform.util.ts
@@ -1,9 +1,9 @@
-import { CreateShuttleRouteForm } from './form.type';
+import { CreateShuttleRouteFormValues } from './form.type';
 import { CreateShuttleRouteRequest } from '@/types/shuttleRoute.type';
 import dayjs from 'dayjs';
 
 export const conform = (
-  data: CreateShuttleRouteForm,
+  data: CreateShuttleRouteFormValues,
 ): CreateShuttleRouteRequest => {
   const validateSequenceOrder = (
     hubs: CreateShuttleRouteRequest['shuttleRouteHubs'],
@@ -46,6 +46,8 @@ export const conform = (
           regionId: string;
           regionHubId: string;
           arrivalTime: string;
+          latitude: number;
+          longitude: number;
         } => dest.regionHubId !== null,
       )
       .map((v, idx) => ({
@@ -64,6 +66,8 @@ export const conform = (
           regionId: string;
           regionHubId: string;
           arrivalTime: string;
+          latitude: number;
+          longitude: number;
         } => dest.regionHubId !== null,
       )
       .map((v, idx) => ({

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/form.type.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/form.type.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const CreateShuttleRouteFormSchema = z.object({
+export const CreateShuttleRouteFormValuesSchema = z.object({
   name: z.string(),
   reservationDeadline: z.string(),
   hasEarlybird: z.boolean(),
@@ -21,6 +21,8 @@ export const CreateShuttleRouteFormSchema = z.object({
       regionId: z.string().nullable(),
       regionHubId: z.string().nullable(),
       arrivalTime: z.string(),
+      latitude: z.number().nullable(),
+      longitude: z.number().nullable(),
     }),
   ),
   shuttleRouteHubsFromDestination: z.array(
@@ -28,10 +30,12 @@ export const CreateShuttleRouteFormSchema = z.object({
       regionId: z.string().nullable(),
       regionHubId: z.string().nullable(),
       arrivalTime: z.string(),
+      latitude: z.number().nullable(),
+      longitude: z.number().nullable(),
     }),
   ),
 });
 
-export type CreateShuttleRouteForm = z.infer<
-  typeof CreateShuttleRouteFormSchema
+export type CreateShuttleRouteFormValues = z.infer<
+  typeof CreateShuttleRouteFormValuesSchema
 >;

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
-import { type CreateShuttleRouteForm } from './form.type';
 import { useRouter } from 'next/navigation';
 import Input from '@/components/input/Input';
 import { RegionHubInputSelfContained } from '@/components/input/HubInput';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import DateInput from '@/components/input/DateInput';
 import DateTimeInput from '@/components/input/DateTimeInput';
 import { useGetEvent } from '@/services/event.service';
@@ -17,6 +16,9 @@ import FormContainer from '@/components/form/Form';
 import Callout from '@/components/text/Callout';
 import NumberInput from '@/components/input/NumberInput';
 import { discountPercent } from '../discountPercent.util';
+import { CreateShuttleRouteFormValues } from './form.type';
+import { calculateUnion } from '../utils/calculate-route';
+import { calculateRoute } from '../utils/calculate-route';
 
 interface Props {
   params: { eventId: string; dailyEventId: string };
@@ -32,7 +34,7 @@ const Page = ({ params }: Props) => {
       ?.date;
   }, [event, dailyEventId]);
 
-  const defaultValues: CreateShuttleRouteForm = useMemo(
+  const defaultValues: CreateShuttleRouteFormValues = useMemo(
     () => ({
       name: '',
       maxPassengerCount: 0,
@@ -53,10 +55,14 @@ const Page = ({ params }: Props) => {
         {
           regionId: null,
           regionHubId: null,
+          latitude: null,
+          longitude: null,
           arrivalTime: defaultDate ?? '',
         },
         {
           regionId: null,
+          latitude: null,
+          longitude: null,
           regionHubId: null,
           arrivalTime: defaultDate ?? '',
         },
@@ -65,11 +71,15 @@ const Page = ({ params }: Props) => {
         {
           regionId: null,
           regionHubId: null,
+          latitude: null,
+          longitude: null,
           arrivalTime: defaultDate ?? '',
         },
         {
           regionId: null,
           regionHubId: null,
+          latitude: null,
+          longitude: null,
           arrivalTime: defaultDate ?? '',
         },
       ],
@@ -94,7 +104,7 @@ export default Page;
 
 interface FormProps extends Props {
   event: EventsViewEntity;
-  defaultValues: CreateShuttleRouteForm;
+  defaultValues: CreateShuttleRouteFormValues;
   defaultDate: string;
 }
 
@@ -111,7 +121,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     formState: { errors },
     getValues,
     setValue,
-  } = useForm<CreateShuttleRouteForm>({
+  } = useForm<CreateShuttleRouteFormValues>({
     defaultValues,
   });
 
@@ -152,7 +162,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     },
   });
 
-  const onSubmit = async (data: CreateShuttleRouteForm) => {
+  const onSubmit = async (data: CreateShuttleRouteFormValues) => {
     if (
       !confirm(
         '추가하시겠습니까? 확인을 누르시면 가격은 더 이상 변경할 수 없습니다. ',
@@ -189,6 +199,22 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
     ).toReversed();
     setValue('shuttleRouteHubsFromDestination', reversedToDestinationHubs);
   };
+
+  const handleCalculateRoute = useCallback(
+    async (type: 'toDestination' | 'fromDestination') => {
+      const hubsArray = getValues(
+        type === 'toDestination'
+          ? 'shuttleRouteHubsToDestination'
+          : 'shuttleRouteHubsFromDestination',
+      );
+      return calculateRoute(type, hubsArray, setValue, getValues);
+    },
+    [],
+  );
+
+  const handleCalculateUnion = useCallback(async () => {
+    return calculateUnion(getValues, setValue);
+  }, []);
 
   return (
     <main>
@@ -388,7 +414,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
             경유지는 장소들 중 선택 가능합니다.
           </Callout>
           <section className="pb-12">
-            <Heading.h5 backgroundColor="yellow">
+            <Heading.h5 backgroundColor="yellow" className="flex">
               가는편
               <button
                 type="button"
@@ -397,11 +423,20 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                     regionId: null,
                     regionHubId: null,
                     arrivalTime: defaultDate,
+                    latitude: null,
+                    longitude: null,
                   })
                 }
                 className="ml-8 text-14 text-blue-500"
               >
                 추가
+              </button>
+              <button
+                type="button"
+                onClick={handleCalculateUnion}
+                className="ml-auto block text-14 text-green-500 underline underline-offset-2"
+              >
+                경로 소요 시간 계산하기
               </button>
             </Heading.h5>
             <ul className="flex flex-col gap-8">
@@ -425,8 +460,17 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                               onChange({ ...value, regionId })
                             }
                             regionHubId={value.regionHubId}
-                            setRegionHubId={(regionHubId) =>
-                              onChange({ ...value, regionHubId })
+                            setRegionHubId={(
+                              regionHubId,
+                              latitude,
+                              longitude,
+                            ) =>
+                              onChange({
+                                ...value,
+                                regionHubId,
+                                latitude,
+                                longitude,
+                              })
                             }
                           />
                         )}
@@ -497,6 +541,8 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                     regionId: null,
                     regionHubId: null,
                     arrivalTime: defaultDate,
+                    latitude: null,
+                    longitude: null,
                   })
                 }
                 className="ml-8 text-14 text-blue-500"
@@ -505,8 +551,15 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
               </button>
               <button
                 type="button"
+                onClick={() => handleCalculateRoute('fromDestination')}
+                className="ml-auto block text-14 text-green-500 underline underline-offset-2"
+              >
+                출발 시간 기준 계산하기
+              </button>
+              <button
+                type="button"
                 onClick={handleMirrorHub}
-                className="ml-auto block text-14 text-blue-500 underline underline-offset-2"
+                className="ml-4 block text-14 text-blue-500 underline underline-offset-2"
               >
                 목적지행을 미러링하기
               </button>
@@ -534,8 +587,17 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
                               onChange({ ...value, regionId })
                             }
                             regionHubId={value.regionHubId}
-                            setRegionHubId={(regionHubId) =>
-                              onChange({ ...value, regionHubId })
+                            setRegionHubId={(
+                              regionHubId,
+                              latitude,
+                              longitude,
+                            ) =>
+                              onChange({
+                                ...value,
+                                regionHubId,
+                                latitude,
+                                longitude,
+                              })
                             }
                           />
                         )}

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/utils/calculate-route.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/utils/calculate-route.ts
@@ -1,0 +1,279 @@
+import dayjs from 'dayjs';
+import { getEstimatedRoute } from '@/services/kakaomoblility.service';
+import {
+  roundDownToNearestFiveMinutes,
+  roundUpToNearestFiveMinutes,
+} from '../components/roundNearestFiveMinutes';
+import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
+import { CreateShuttleRouteFormValues } from '../new/form.type';
+
+/**
+ * 경로 계산을 위한 허브 데이터 타입
+ */
+export interface RouteHubData {
+  regionId: string | null;
+  regionHubId: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  arrivalTime: string;
+}
+
+/**
+ * 출발 시간 기준으로 경로를 계산하고 도착 시간을 설정합니다.
+ */
+export const calculateRoute = async (
+  type: 'toDestination' | 'fromDestination',
+  hubsArray: RouteHubData[],
+  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
+  getValues: UseFormGetValues<CreateShuttleRouteFormValues>,
+): Promise<string | undefined> => {
+  // 필수 데이터 유효성 검사
+  const isInvalid = hubsArray.some((hub) => !hub.regionId || !hub.regionHubId);
+
+  if (isInvalid || hubsArray.length < 2 || !hubsArray[0].arrivalTime) {
+    alert('모든 경유지의 지역, 정류장, 첫 정류장의 시간이 입력되어야 합니다.');
+    return;
+  }
+
+  try {
+    const origin = `${hubsArray[0].longitude},${hubsArray[0].latitude}`;
+    const destination = `${hubsArray[hubsArray.length - 1].longitude},${hubsArray[hubsArray.length - 1].latitude}`;
+    const waypoints = hubsArray
+      .slice(1, -1)
+      .map((hub) => `${hub.longitude},${hub.latitude}`)
+      .join('|');
+    const departureTime = dayjs(hubsArray[0].arrivalTime)
+      .tz('Asia/Seoul')
+      .format('YYYYMMDDHHmm');
+
+    const res = await getEstimatedRoute({
+      origin,
+      destination,
+      waypoints,
+      departureTime,
+    });
+
+    if (res.routes[0].result_code !== 0) {
+      throw new Error(res.routes[0].result_msg);
+    }
+
+    const result = res.routes.map((route) => ({
+      distance: route.summary.distance,
+      duration: route.summary.duration,
+      sections: route.sections.map((section) => ({
+        distance: section.distance,
+        duration: section.duration,
+      })),
+    }));
+
+    let currentTime = dayjs(hubsArray[0].arrivalTime);
+    hubsArray.forEach((_, index) => {
+      if (index === 0) return;
+
+      // 시간 추가 후 바로 5분 단위로 올림 처리
+      currentTime = roundUpToNearestFiveMinutes(
+        currentTime.add(result[0].sections[index - 1].duration, 'seconds'),
+      );
+
+      setValue(
+        type === 'toDestination'
+          ? `shuttleRouteHubsToDestination.${index}.arrivalTime`
+          : `shuttleRouteHubsFromDestination.${index}.arrivalTime`,
+        currentTime.toISOString(),
+      );
+    });
+
+    alert(
+      `출발시간 기준 경로 계산이 완료되었습니다.\n출발시간 : ${dayjs(hubsArray[0].arrivalTime).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm')}\n총 소요시간 : ${Math.floor(result[0].duration / 60)}분\n총 거리 : ${result[0].distance}m
+      ${hubsArray.map((_, index) => {
+        if (index === 0) return '\n경유지 별 소요시간';
+        return `\n${index}번째 경유지 : ${Math.floor(
+          result[0].sections[index - 1].duration / 60,
+        )}분`;
+      })}`,
+    );
+
+    const destinationArrivalTime = getValues(
+      type === 'toDestination'
+        ? 'shuttleRouteHubsToDestination'
+        : 'shuttleRouteHubsFromDestination',
+    );
+    return destinationArrivalTime[hubsArray.length - 1].arrivalTime;
+  } catch (error) {
+    console.error('경로 계산 중 오류 발생:', error);
+    alert(
+      '경로 계산 중 오류가 발생했습니다.' +
+        (error instanceof Error && error.message),
+    );
+    return;
+  }
+};
+
+/**
+ * 도착 시간 기준으로 경로를 계산하고 출발 시간을 설정합니다.
+ */
+export const calculateRouteBackward = async (
+  type: 'toDestination' | 'fromDestination',
+  hubsArray: RouteHubData[],
+  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
+): Promise<string | undefined> => {
+  // 필수 데이터 유효성 검사
+  const isInvalid = hubsArray.some((hub) => !hub.regionId || !hub.regionHubId);
+
+  // 마지막 정류장(도착지)의 시간이 필요
+  const lastIndex = hubsArray.length - 1;
+  if (isInvalid || hubsArray.length < 2 || !hubsArray[lastIndex].arrivalTime) {
+    alert('모든 경유지의 지역, 정류장, 도착지의 시간이 입력되어야 합니다.');
+    return;
+  }
+
+  try {
+    // 1. 임의의 출발 시간으로 API 호출하여 소요 시간 정보 확보
+    const origin = `${hubsArray[0].longitude},${hubsArray[0].latitude}`;
+    const destination = `${hubsArray[lastIndex].longitude},${hubsArray[lastIndex].latitude}`;
+    const waypoints = hubsArray
+      .slice(1, -1)
+      .map((hub) => `${hub.longitude},${hub.latitude}`)
+      .join('|');
+
+    // 임의의 출발 시간
+    const tempDepartureTime = dayjs().format('YYYYMMDDHHmm');
+
+    const res = await getEstimatedRoute({
+      origin,
+      destination,
+      waypoints,
+      departureTime: tempDepartureTime,
+    });
+
+    if (res.routes[0].result_code !== 0) {
+      throw new Error(res.routes[0].result_msg);
+    }
+
+    const result = res.routes[0];
+    const totalDuration = result.summary.duration; // 총 소요 시간(초)
+
+    // 2. 도착 시간에서 총 소요 시간을 빼서 실제 출발 시간 계산
+    const arrivalTime = dayjs(hubsArray[lastIndex].arrivalTime).tz(
+      'Asia/Seoul',
+    );
+    const actualDepartureTime = arrivalTime.subtract(totalDuration, 'second');
+
+    const roundedActualDepartureTime =
+      roundDownToNearestFiveMinutes(actualDepartureTime);
+
+    // 3. 출발 시간 설정
+    setValue(
+      type === 'toDestination'
+        ? `shuttleRouteHubsToDestination.0.arrivalTime`
+        : `shuttleRouteHubsFromDestination.0.arrivalTime`,
+      roundedActualDepartureTime.toISOString(),
+    );
+
+    // 4. 각 경유지 시간 계산
+    let currentTime = actualDepartureTime;
+    for (let i = 1; i < hubsArray.length; i++) {
+      if (i < result.sections.length) {
+        // 시간 추가 후 바로 5분 단위로 올림 처리
+        currentTime = roundUpToNearestFiveMinutes(
+          currentTime.add(result.sections[i - 1].duration, 'second'),
+        );
+
+        // 중간 경유지 시간 설정 (마지막은 이미 설정되어 있음)
+        if (i < lastIndex) {
+          setValue(
+            type === 'toDestination'
+              ? `shuttleRouteHubsToDestination.${i}.arrivalTime`
+              : `shuttleRouteHubsFromDestination.${i}.arrivalTime`,
+            currentTime.toISOString(),
+          );
+        }
+      }
+    }
+
+    alert(
+      `도착시간 기준 경로 계산이 완료되었습니다.\n출발 시간이 ${roundedActualDepartureTime.format('HH:mm')}로 설정되었습니다.\n` +
+        `총 소요시간: ${Math.floor(totalDuration / 60)}분\n총 거리: ${result.summary.distance}m
+        ${hubsArray.map((_, index) => {
+          if (index === 0) return '\n경유지 별 소요시간';
+          return `\n${index}번째 경유지 : ${Math.floor(
+            result.sections[index - 1].duration / 60,
+          )}분`;
+        })}`,
+    );
+
+    return roundedActualDepartureTime.toISOString();
+  } catch (error) {
+    console.error('경로 계산 중 오류 발생:', error);
+    alert(
+      '경로 계산 중 오류가 발생했습니다.' +
+        (error instanceof Error && error.message),
+    );
+    return;
+  }
+};
+
+/**
+ * 출발시간과 도착시간을 모두 고려하여 경로를 계산합니다.
+ */
+export const calculateUnion = async (
+  getValues: UseFormGetValues<CreateShuttleRouteFormValues>,
+  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
+): Promise<void> => {
+  const hubsArray = getValues('shuttleRouteHubsToDestination');
+  const plannedArrivalTime = hubsArray[hubsArray.length - 1].arrivalTime;
+
+  alert('도착시간 기준 경로를 계산합니다. 재조정이 있을 수 있습니다.');
+
+  try {
+    // 1. 도착 시간 기준으로 출발 시간 계산
+    const estimatedDepartureTime = await calculateRouteBackward(
+      'toDestination',
+      hubsArray,
+      setValue,
+    );
+
+    // 2. 출발 시간 기준으로 도착 시간 계산
+    const estimatedDestinationArrivalTime = await calculateRoute(
+      'toDestination',
+      hubsArray,
+      setValue,
+      getValues,
+    );
+
+    if (!estimatedDepartureTime || !estimatedDestinationArrivalTime) {
+      return;
+    }
+
+    // 3. 예상 도착 시간과 계획된 도착 시간 비교
+    const diff = dayjs(estimatedDestinationArrivalTime).diff(
+      estimatedDepartureTime,
+      'minute',
+    );
+
+    if (diff >= 10) {
+      alert('예상 도착시간이 10분 이상 벗어나 재조정합니다');
+      const arrivalTimeDifference = dayjs(plannedArrivalTime).diff(
+        estimatedDestinationArrivalTime,
+        'minute',
+      );
+      setValue(
+        'shuttleRouteHubsToDestination.0.arrivalTime',
+        dayjs(getValues('shuttleRouteHubsToDestination.0.arrivalTime'))
+          .add(arrivalTimeDifference, 'minute')
+          .toISOString(),
+      );
+      await calculateRoute(
+        'toDestination',
+        getValues('shuttleRouteHubsToDestination'),
+        setValue,
+        getValues,
+      );
+    }
+  } catch (error) {
+    console.error('경로 계산 통합 중 오류 발생:', error);
+    alert(
+      `경로 계산 통합 중 오류가 발생했습니다: ${error instanceof Error && error.message}`,
+    );
+  }
+};

--- a/src/components/input/HubInput.tsx
+++ b/src/components/input/HubInput.tsx
@@ -18,7 +18,11 @@ import Link from 'next/link';
 interface Props {
   regionId: string | undefined;
   value: string | null;
-  setValue: (value: string | null) => void;
+  setValue: (
+    value: string | null,
+    latitude: number | null,
+    longitude: number | null,
+  ) => void;
 }
 
 const RegionHubInput = ({ regionId, value, setValue }: Props) => {
@@ -39,7 +43,11 @@ const RegionHubInput = ({ regionId, value, setValue }: Props) => {
 
   const setSelectedHub = useCallback(
     (hub: RegionHub | null) => {
-      setValue(hub?.regionHubId ?? null);
+      setValue(
+        hub?.regionHubId ?? null,
+        hub?.latitude ?? null,
+        hub?.longitude ?? null,
+      );
     },
     [setValue],
   );
@@ -131,7 +139,11 @@ export const RegionHubInputSelfContained = ({
   regionId: string | null;
   setRegionId: (value: string | null) => void;
   regionHubId: string | null;
-  setRegionHubId: (value: string | null) => void;
+  setRegionHubId: (
+    value: string | null,
+    latitude: number | null,
+    longitude: number | null,
+  ) => void;
 }) => {
   return (
     <div className="flex flex-col gap-4">

--- a/src/services/kakaomoblility.service.ts
+++ b/src/services/kakaomoblility.service.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import {
+  FutureRouteSchema,
+  FutureRouteSchemaType,
+} from '@/types/kakaomoblity.type';
+import { silentParse } from '@/utils/parse.util';
+
+const REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY;
+const BASE_URL = 'https://apis-navi.kakaomobility.com/v1/future/directions';
+
+// api docs : https://developers.kakaomobility.com/docs/navi-api/future/
+
+interface Props {
+  departureTime: string; // YYYYMMDDHHMM 형식,
+  origin: string; // x,y or x,y,name or x,y,angle
+  waypoints?: string; // max 5, under 1,500km, each waypoint has x,y,name or x,y with | or %7C
+  destination: string; // x,y,name or x,y
+  priority?: string; // RECOMMEND, TIME, DISTANCE, (default: RECOMMEND)
+  roadevent?: number; // 교통사고 등 도로 통제 정보 반영 옵션 (default: 0 모두반영)
+  road_details?: boolean; // 도로 상세 정보 제공여부 (default: false)
+  car_type?: number; // 차종 (default: 1)
+  summary?: boolean; // 경로 요약 정보 제공여부 (default: true)
+  avoid?: string; // ferries, toll, motorway, schoolzone, uturn , default: none
+  alternatives?: boolean; // 대안경로 제공여부 (default: false)
+  car_fuel?: string; // 연료종류 (default: GASOLINE)
+  car_hipass?: boolean; // 하이패스 여부 (default: false)
+}
+
+export const getEstimatedRoute = async ({
+  departureTime,
+  origin,
+  waypoints,
+  destination,
+  priority = 'RECOMMEND',
+  roadevent,
+  road_details,
+  car_type = 3, // 고속버스 이므로 대형
+  summary = true,
+}: Props): Promise<FutureRouteSchemaType> => {
+  const url = new URL(BASE_URL);
+  url.searchParams.append('origin', origin);
+  url.searchParams.append('destination', destination);
+  url.searchParams.append('departure_time', departureTime);
+
+  if (waypoints) url.searchParams.append('waypoints', waypoints);
+  if (priority) url.searchParams.append('priority', priority);
+  if (roadevent !== undefined)
+    url.searchParams.append('roadevent', roadevent.toString());
+  if (road_details !== undefined)
+    url.searchParams.append('road_details', road_details.toString());
+  if (car_type !== undefined)
+    url.searchParams.append('car_type', car_type.toString());
+  if (summary !== undefined)
+    url.searchParams.append('summary', summary.toString());
+
+  const { trans_id, routes } = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      Authorization: `KakaoAK ${REST_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => res.json());
+
+  const ApiResponseOkSchema = <T extends z.ZodRawShape>(rawShape: T) =>
+    z
+      .object({ ok: z.literal(true), statusCode: z.number() })
+      .merge(z.object(rawShape))
+      .strict();
+
+  const schema = ApiResponseOkSchema(FutureRouteSchema.shape);
+
+  return silentParse(
+    schema,
+    {
+      ok: true,
+      statusCode: routes.result_code,
+      errorMsg: routes.result_msg,
+      trans_id: trans_id,
+      routes: routes,
+    },
+    {
+      useToast: false,
+    },
+  );
+};

--- a/src/types/kakaomoblity.type.ts
+++ b/src/types/kakaomoblity.type.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+export const FutureRouteSchema = z.object({
+  trans_id: z.string(),
+  routes: z.array(
+    z.object({
+      result_code: z.number(),
+      result_msg: z.string(),
+      summary: z.object({
+        origin: z.object({
+          name: z.string(),
+          x: z.number(),
+          y: z.number(),
+        }),
+        destination: z.object({
+          name: z.string(),
+          x: z.number(),
+          y: z.number(),
+        }),
+        waypoints: z.array(
+          z.object({
+            name: z.string(),
+            x: z.number(),
+            y: z.number(),
+          }),
+        ),
+        priority: z.string(),
+        bound: z
+          .object({
+            min_x: z.number(),
+            min_y: z.number(),
+            max_x: z.number(),
+            max_y: z.number(),
+          })
+          .optional(),
+        fare: z.object({
+          taxi: z.number(),
+          toll: z.number(),
+        }),
+        distance: z.number(),
+        duration: z.number(),
+      }),
+      sections: z.array(
+        z.object({
+          distance: z.number(),
+          duration: z.number(),
+          bound: z
+            .object({
+              min_x: z.number(),
+              min_y: z.number(),
+              max_x: z.number(),
+              max_y: z.number(),
+            })
+            .optional(),
+          roads: z
+            .array(
+              z.object({
+                name: z.string(),
+                distance: z.number(),
+                duration: z.number(),
+                traffic_speed: z.number(),
+                traffic_state: z.number(),
+                vertexes: z.array(z.number()),
+              }),
+            )
+            .optional(),
+          guide: z
+            .object({
+              name: z.string(),
+              x: z.number(),
+              y: z.number(),
+              distance: z.number(),
+              duration: z.number(),
+              type: z.string(),
+              guidance: z.string(),
+              road_index: z.number(),
+            })
+            .optional(),
+        }),
+      ),
+    }),
+  ),
+});
+
+export type FutureRouteSchemaType = z.infer<typeof FutureRouteSchema>;


### PR DESCRIPTION
## 개요

노선 경로 자동 계산기를 적용하였습니다.
가는 편은 도착시간을 기준으로, 오는 편은 출발 시간을 기준으로 모든 경유지의 시각을 계산해줍니다.

kakaomobility 미래 운행 정보 길찾기 api를 사용하였습니다 (https://developers.kakaomobility.com/docs/navi-api/future/)
미래 시각의 도로정보 등의 상황을 반영한 길찾기 정보를 알려줍니다.
- 출발시간 기준 계산 : 설정한 출발시간을 기준으로 계산합니다.
- 도착시간 기준 계산 : 현재 시각을 기준으로 총 소요되는 시각을 구한 뒤, 이를 역산하여 출발시간을 알아냅니다. 다만, 현재시간과 설정한 출발시간이 달라 소요시간이 다를 수 있어서 도출된 출발시간을 기준으로 다시 경로 소요시간을 계산합니다.
이때, 도출된 도착시간이 처음 설정한 도착시간과 10분이상 차이날 땐 시간차 만큼 출발시간을 보상한 뒤 최종적으로 경로 소요시간을 계산합니다.

https://github.com/user-attachments/assets/4eab3cec-47f5-43d8-ba4b-d6c790fbd8b9



## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).