### PR TITLE
feat: 장소 - 지도 인터렉션 기능 추가 및 개선

### DIFF
--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -17,6 +17,7 @@ import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
 import { RegionHub } from '@/types/hub.type';
+import MapGuides from '@/app/locations/components/MapGuides';
 
 const EditHubPage = ({
   params,
@@ -130,6 +131,7 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
         </Form.section>
         <Form.section>
           <Form.label>위치 및 좌표</Form.label>
+          <MapGuides />
           <Controller
             control={control}
             name={`coord`}

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -17,7 +17,7 @@ import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
 import { RegionHub } from '@/types/hub.type';
-import MapGuides from '@/app/locations/components/MapGuides';
+import { MapGuidesNewEditPage } from '@/app/locations/components/MapGuides';
 
 const EditHubPage = ({
   params,
@@ -131,7 +131,7 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
         </Form.section>
         <Form.section>
           <Form.label>위치 및 좌표</Form.label>
-          <MapGuides />
+          <MapGuidesNewEditPage />
           <Controller
             control={control}
             name={`coord`}

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -17,7 +17,7 @@ import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
 import { RegionHub } from '@/types/hub.type';
-import { MapGuidesNewEditPage } from '@/app/locations/components/MapGuides';
+import MapGuidesAtNewEditPage from '@/app/locations/components/MapGuidesAtNewEditPage';
 
 const EditHubPage = ({
   params,
@@ -131,7 +131,7 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
         </Form.section>
         <Form.section>
           <Form.label>위치 및 좌표</Form.label>
-          <MapGuidesNewEditPage />
+          <MapGuidesAtNewEditPage />
           <Controller
             control={control}
             name={`coord`}

--- a/src/app/locations/components/MapGuides.tsx
+++ b/src/app/locations/components/MapGuides.tsx
@@ -1,6 +1,6 @@
 import Callout from '@/components/text/Callout';
 
-const MapGuides = () => {
+export const MapGuides = () => {
   return (
     <Callout className="mx-16">
       <p>도움말</p>
@@ -19,4 +19,15 @@ const MapGuides = () => {
   );
 };
 
-export default MapGuides;
+export const MapGuidesNewEditPage = () => {
+  return (
+    <Callout className="mx-16">
+      <p>도움말</p>
+      <ul>
+        <li>1. 오른쪽 클릭 : 지도에 핀을 놓습니다.</li>
+        <li>2. 노란색 핀들은 존재하는 정류장입니다.</li>
+        <li>3. 더블클릭 : Zoom-in 효과</li>
+      </ul>
+    </Callout>
+  );
+};

--- a/src/app/locations/components/MapGuides.tsx
+++ b/src/app/locations/components/MapGuides.tsx
@@ -1,6 +1,6 @@
 import Callout from '@/components/text/Callout';
 
-export const MapGuides = () => {
+const MapGuides = () => {
   return (
     <Callout className="mx-16">
       <p>도움말</p>
@@ -19,15 +19,4 @@ export const MapGuides = () => {
   );
 };
 
-export const MapGuidesNewEditPage = () => {
-  return (
-    <Callout className="mx-16">
-      <p>도움말</p>
-      <ul>
-        <li>1. 오른쪽 클릭 : 지도에 핀을 놓습니다.</li>
-        <li>2. 노란색 핀들은 존재하는 정류장입니다.</li>
-        <li>3. 더블클릭 : Zoom-in 효과</li>
-      </ul>
-    </Callout>
-  );
-};
+export default MapGuides;

--- a/src/app/locations/components/MapGuides.tsx
+++ b/src/app/locations/components/MapGuides.tsx
@@ -1,0 +1,22 @@
+import Callout from '@/components/text/Callout';
+
+const MapGuides = () => {
+  return (
+    <Callout className="mx-16">
+      <p>도움말</p>
+      <ul>
+        <li>
+          1. 오른쪽 클릭 : 지도에 핀을 놓습니다. 핀을 클릭하면 해당 정류장을
+          생성하는 페이지가 열립니다.
+        </li>
+        <li>
+          2. 노란색 핀들은 존재하는 정류장입니다. 마우스를 올리면 해당 정류장의
+          이름이 표시됩니다. 클릭하면 해당 정류장의 수정 페이지로 이동합니다.
+        </li>
+        <li>3. 더블클릭 : Zoom-in 효과</li>
+      </ul>
+    </Callout>
+  );
+};
+
+export default MapGuides;

--- a/src/app/locations/components/MapGuidesAtNewEditPage.tsx
+++ b/src/app/locations/components/MapGuidesAtNewEditPage.tsx
@@ -1,0 +1,16 @@
+import Callout from '@/components/text/Callout';
+
+const MapGuidesAtNewEditPage = () => {
+  return (
+    <Callout className="mx-16">
+      <p>도움말</p>
+      <ul>
+        <li>1. 오른쪽 클릭 : 지도에 핀을 놓습니다.</li>
+        <li>2. 노란색 핀들은 존재하는 정류장입니다.</li>
+        <li>3. 더블클릭 : Zoom-in 효과</li>
+      </ul>
+    </Callout>
+  );
+};
+
+export default MapGuidesAtNewEditPage;

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -94,7 +94,7 @@ const HubsMap = () => {
   }, []);
 
   useEffect(() => {
-    if (window.kakao?.maps) {
+    if (window.kakao?.maps && markerRef.current) {
       setMarker(new window.kakao.maps.LatLng(coord.latitude, coord.longitude));
     }
   }, [coord, setMarker]);

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -69,21 +69,20 @@ const HubsMap = () => {
   }, []);
 
   const setCoordWithAddress = useCallback(
-    (latLng: kakao.maps.LatLng) => {
+    async (latLng: kakao.maps.LatLng) => {
       const latitude = latLng.getLat();
       const longitude = latLng.getLng();
 
       setLoading(true);
-      toAddress(latitude, longitude)
-        .then((address) => {
-          setLoading(false);
-          setCoord({ latitude, longitude, address: address.address_name });
-        })
-        .catch(() => {
-          setLoading(false);
-          setCoord({ latitude, longitude, address: 'unknown address' });
-          setError(true);
-        });
+      try {
+        const address = await toAddress(latitude, longitude);
+        setLoading(false);
+        setCoord({ latitude, longitude, address: address.address_name });
+      } catch {
+        setLoading(false);
+        setCoord({ latitude, longitude, address: 'unknown address' });
+        setError(true);
+      }
     },
     [setCoord],
   );

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -197,24 +197,6 @@ const HubsMap = () => {
     [],
   );
 
-  const handleMapClick = useCallback(
-    (
-      map: kakao.maps.Map,
-      mouseEvent: kakao.maps.event.MouseEvent,
-      clickMarkerOverlay: kakao.maps.CustomOverlay,
-    ) => {
-      setCoordWithAddress(mouseEvent.latLng);
-      clickMarkerOverlay.setPosition(mouseEvent.latLng);
-
-      const currentLevel = map.getLevel();
-      if (currentLevel >= 6) {
-        map.setCenter(mouseEvent.latLng);
-        map.setLevel(currentLevel - 1);
-      }
-    },
-    [setCoordWithAddress],
-  );
-
   const setupSearch = useCallback(() => {
     const ps = new window.kakao.maps.services.Places();
     const searchInput = document.getElementById('search-input');
@@ -255,9 +237,10 @@ const HubsMap = () => {
 
         window.kakao.maps.event.addListener(
           map,
-          'click',
+          'rightclick',
           (mouseEvent: kakao.maps.event.MouseEvent) => {
-            handleMapClick(map, mouseEvent, clickMarkerOverlay);
+            setCoordWithAddress(mouseEvent.latLng);
+            clickMarkerOverlay.setPosition(mouseEvent.latLng);
           },
         );
 
@@ -273,7 +256,6 @@ const HubsMap = () => {
     coord.latitude,
     coord.longitude,
     setupClickMarker,
-    handleMapClick,
     setupSearch,
     regionHubsData,
   ]);

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { twJoin } from 'tailwind-merge';
 import { BanIcon, Loader2Icon } from 'lucide-react';
 import { useGetRegionHubs } from '@/services/hub.service';
-import { toAddress } from '@/utils/region.uitl';
+import { toAddress } from '@/utils/region.util';
 import KakaoMapScript from '@/components/script/KakaoMapScript';
 import { createOverlayHTML } from '../createOverlayHTML.util';
 interface HubData {
@@ -77,7 +77,7 @@ const HubsMap = () => {
       toAddress(latitude, longitude)
         .then((address) => {
           setLoading(false);
-          setCoord({ latitude, longitude, address });
+          setCoord({ latitude, longitude, address: address.address_name });
         })
         .catch(() => {
           setLoading(false);
@@ -180,13 +180,13 @@ const HubsMap = () => {
         clickMarkerOverlay.setMap(null);
       });
 
-      kakao.maps.event.addListener(marker, 'click', () => {
+      kakao.maps.event.addListener(marker, 'click', async () => {
         const position = marker.getPosition();
         const latitude = position.getLat();
         const longitude = position.getLng();
-        const address = toAddress(latitude, longitude);
+        const address = await toAddress(latitude, longitude);
         window.open(
-          `/locations/new?latitude=${latitude}&longitude=${longitude}&address=${address}`,
+          `/locations/new?latitude=${latitude}&longitude=${longitude}&address=${address.address_name}`,
           '_blank',
           'noopener',
         );

--- a/src/app/locations/map/page.tsx
+++ b/src/app/locations/map/page.tsx
@@ -2,7 +2,7 @@
 
 import HubsMap from './components/hubsMap';
 import Heading from '@/components/text/Heading';
-import MapGuides from '../components/MapGuides';
+import { MapGuides } from '../components/MapGuides';
 
 const Page = () => {
   return (

--- a/src/app/locations/map/page.tsx
+++ b/src/app/locations/map/page.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import Callout from '@/components/text/Callout';
 import HubsMap from './components/hubsMap';
 import Heading from '@/components/text/Heading';
+import MapGuides from '../components/MapGuides';
 
 const Page = () => {
   return (
     <div>
       <Heading.h1>지도 보기</Heading.h1>
-      <Callout>
-        <p>도움말</p>
-        <ul>
-          <li>
-            1. 줌 레벨이 높을때 지도를 클릭하면 해당 위치를 중심으로 지도가
-            이동합니다.
-          </li>
-          <li>
-            2. 노란색 핀에 마우스를 올리면 해당 정류장의 이름이 표시됩니다.
-          </li>
-          <li>3. 핀을 클릭하면 해당 정류장의 수정 페이지로 이동합니다.</li>
-        </ul>
-      </Callout>
+      <MapGuides />
       <HubsMap />
     </div>
   );

--- a/src/app/locations/map/page.tsx
+++ b/src/app/locations/map/page.tsx
@@ -2,7 +2,7 @@
 
 import HubsMap from './components/hubsMap';
 import Heading from '@/components/text/Heading';
-import { MapGuides } from '../components/MapGuides';
+import MapGuides from '../components/MapGuides';
 
 const Page = () => {
   return (

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -27,9 +27,9 @@ const NewHubPage = ({
       regionId: undefined,
       name: '',
       coord: {
-        address: searchParams.address ?? '',
-        latitude: parseFloat(searchParams.latitude) ?? 0,
-        longitude: parseFloat(searchParams.longitude) ?? 0,
+        address: searchParams.address || '',
+        latitude: parseFloat(searchParams.latitude) || 37.574187,
+        longitude: parseFloat(searchParams.longitude) || 126.976882,
       },
     },
   });

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -12,7 +12,7 @@ import { useGetRegions, usePostRegionHub } from '@/services/hub.service';
 import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
-import MapGuides from '../components/MapGuides';
+import { MapGuidesNewEditPage } from '../components/MapGuides';
 
 const NewHubPage = ({
   searchParams,
@@ -88,7 +88,7 @@ const NewHubPage = ({
         </Form.section>
         <Form.section>
           <Form.label>위치 및 좌표</Form.label>
-          <MapGuides />
+          <MapGuidesNewEditPage />
           <Controller
             control={control}
             name={`coord`}

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -12,7 +12,7 @@ import { useGetRegions, usePostRegionHub } from '@/services/hub.service';
 import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
-import { MapGuidesNewEditPage } from '../components/MapGuides';
+import MapGuidesAtNewEditPage from '../components/MapGuidesAtNewEditPage';
 
 const NewHubPage = ({
   searchParams,
@@ -88,7 +88,7 @@ const NewHubPage = ({
         </Form.section>
         <Form.section>
           <Form.label>위치 및 좌표</Form.label>
-          <MapGuidesNewEditPage />
+          <MapGuidesAtNewEditPage />
           <Controller
             control={control}
             name={`coord`}

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -12,6 +12,7 @@ import { useGetRegions, usePostRegionHub } from '@/services/hub.service';
 import { Region } from '@/types/region.type';
 import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
+import MapGuides from '../components/MapGuides';
 
 const NewHubPage = ({
   searchParams,
@@ -87,6 +88,7 @@ const NewHubPage = ({
         </Form.section>
         <Form.section>
           <Form.label>위치 및 좌표</Form.label>
+          <MapGuides />
           <Controller
             control={control}
             name={`coord`}

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -5,8 +5,8 @@ import { twJoin } from 'tailwind-merge';
 import { BanIcon, Loader2Icon, RotateCwIcon } from 'lucide-react';
 import KakaoMapScript from '../script/KakaoMapScript';
 import { useGetRegionHubsWithoutPagination } from '@/services/hub.service';
-import { findRegionId, toAddress } from '@/utils/region.uitl';
-import { standardizeRegionName } from '@/utils/region.uitl';
+import { findRegionId, toAddress } from '@/utils/region.util';
+import { standardizeRegionName } from '@/utils/region.util';
 
 interface Props {
   coord: Coord;
@@ -62,7 +62,7 @@ const CoordInput = ({ coord, setCoord }: Props) => {
       toAddress(latitude, longitude)
         .then((address) => {
           setLoading(false);
-          setCoord({ latitude, longitude, address });
+          setCoord({ latitude, longitude, address: address.address_name });
         })
         .catch(() => {
           setLoading(false);
@@ -159,20 +159,16 @@ const CoordInput = ({ coord, setCoord }: Props) => {
 
     try {
       const address = await toAddress(center.getLat(), center.getLng());
-      const addressParts = address.split(' ');
-
-      if (addressParts.length >= 2) {
-        const bigRegion = standardizeRegionName(addressParts[0]);
-        const smallRegion = addressParts[1];
-        const region = `${bigRegion} ${smallRegion}`;
-        const regionId = findRegionId(bigRegion, smallRegion);
-        setCurrentRegion(region);
-        setCurrentRegionId(typeof regionId === 'string' ? regionId : null);
-        return regionId;
-      }
-      return null;
+      const bigRegion = standardizeRegionName(address.region_1depth_name);
+      const smallRegion = address.region_2depth_name;
+      const region = `${bigRegion} ${smallRegion}`;
+      const regionId = findRegionId(bigRegion, smallRegion);
+      setCurrentRegion(region);
+      setCurrentRegionId(typeof regionId === 'string' ? regionId : null);
+      return regionId;
     } catch (error) {
       console.error('지역 정보를 가져오는 데 실패했습니다.', error);
+      setError(true);
       return null;
     }
   };
@@ -228,31 +224,13 @@ const CoordInput = ({ coord, setCoord }: Props) => {
 
         window.kakao.maps.event.addListener(map, 'dragend', async () => {
           if (map) {
-            const center = map.getCenter();
-            try {
-              const address = await toAddress(center.getLat(), center.getLng());
-              const addressParts = address.split(' ');
-              if (addressParts.length >= 2) {
-                getCurrentRegion();
-              }
-            } catch (error) {
-              console.error('지역 정보를 가져오는 데 실패했습니다.', error);
-            }
+            getCurrentRegion();
           }
         });
 
         window.kakao.maps.event.addListener(map, 'zoom_changed', async () => {
           if (map) {
-            const center = map.getCenter();
-            try {
-              const address = await toAddress(center.getLat(), center.getLng());
-              const addressParts = address.split(' ');
-              if (addressParts.length >= 2) {
-                getCurrentRegion();
-              }
-            } catch (error) {
-              console.error('지역 정보를 가져오는 데 실패했습니다.', error);
-            }
+            getCurrentRegion();
           }
         });
 

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -220,15 +220,9 @@ const CoordInput = ({ coord, setCoord }: Props) => {
 
         window.kakao.maps.event.addListener(
           map,
-          'click',
+          'rightclick',
           (mouseEvent: kakao.maps.event.MouseEvent) => {
             setCoordWithAddress(mouseEvent.latLng);
-
-            const currentLevel = map.getLevel();
-            if (currentLevel >= 6) {
-              map.setCenter(mouseEvent.latLng);
-              map.setLevel(currentLevel - 1);
-            }
           },
         );
 
@@ -324,7 +318,7 @@ const CoordInput = ({ coord, setCoord }: Props) => {
             <input
               id="search-input"
               type="text"
-              placeholder="키워드로 검색"
+              placeholder="키워드로 지도 검색"
               className="h-full w-full p-12 outline-none"
             />
           </div>

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -54,21 +54,20 @@ const CoordInput = ({ coord, setCoord }: Props) => {
   );
 
   const setCoordWithAddress = useCallback(
-    (latLng: kakao.maps.LatLng) => {
+    async (latLng: kakao.maps.LatLng) => {
       const latitude = latLng.getLat();
       const longitude = latLng.getLng();
 
       setLoading(true);
-      toAddress(latitude, longitude)
-        .then((address) => {
-          setLoading(false);
-          setCoord({ latitude, longitude, address: address.address_name });
-        })
-        .catch(() => {
-          setLoading(false);
-          setCoord({ latitude, longitude, address: 'unknown address' });
-          setError(true);
-        });
+      try {
+        const address = await toAddress(latitude, longitude);
+        setLoading(false);
+        setCoord({ latitude, longitude, address: address.address_name });
+      } catch {
+        setLoading(false);
+        setCoord({ latitude, longitude, address: 'unknown address' });
+        setError(true);
+      }
     },
     [setCoord],
   );

--- a/src/utils/region.util.ts
+++ b/src/utils/region.util.ts
@@ -1,7 +1,7 @@
 import { REGION_TO_ID } from '@/constants/regions';
 
-export const toAddress = async (latitude: number, longitude: number) =>
-  new Promise<string>((resolve, reject) => {
+export const toAddress = (latitude: number, longitude: number) =>
+  new Promise<kakao.maps.services.Address>((resolve, reject) => {
     if (!window.kakao?.maps?.services) reject('Geocoder is not available');
 
     const geocoder = new window.kakao.maps.services.Geocoder();
@@ -14,7 +14,7 @@ export const toAddress = async (latitude: number, longitude: number) =>
       status: kakao.maps.services.Status,
     ) => {
       if (status === window.kakao.maps.services.Status.OK) {
-        const address = result[0].address.address_name;
+        const address = result[0].address;
         resolve(address);
       } else {
         reject('Geocoder failed');


### PR DESCRIPTION
## 개요
어드민 장소에서 사용하던 지도의 인터렉션 기능 추가 및 개선

## 변경사항
#### 기능 추가
- 줌 레벨이 6 이상 일때 지도를 왼쪽 클릭 하게되면 줌 인이 되는 방식에서 더블클릭시 줌 인으로 간단하게 변경
- 기존의 방식인 마우스 왼쪽 클릭 대신 마우스 오른쪽 클릭시 핀을 설정합니다.
- 도움말이 추가되었습니다.

#### 버그 수정
- 지도 보기 페이지에서 첫 렌더링시에 에러가 발생하던 이슈
- 지도 추가/수정하기에서 drag end, zoom changed 시 마다 kakao api (geocoder.coord2Address) 가 2번씩 호출되던 이슈

#### 개선사항
- address 를 split 해서 쓰지 않고 kakao api 에서 제공되는 depth name을 사용하도록 변경
- region.uitl.ts 와 같은 오타 수정
- toAddress 는 new Promise 를 반환하므로 async 키워드가 필요없습니다. -> async 삭제
- then 을 사용하지 않고 async await 을 사용하도록 변경

https://github.com/user-attachments/assets/2a45b0a5-411b-4a0d-ac5e-96e70c1addce


#### 추가된 도움말 (순서대로 장소 추가/생성, 지도보기)
<img width="424" alt="Screenshot 2025-03-21 at 5 22 52 PM" src="https://github.com/user-attachments/assets/4fbf4557-ea84-4f05-979b-0c6c92a432ad" />

<img width="482" alt="Screenshot 2025-03-21 at 5 23 00 PM" src="https://github.com/user-attachments/assets/900785a3-e1fa-4d80-becf-47acc1546831" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).