### PR TITLE
refactor: 코드 개선 및 alert 3번 뜨는 것 방지 (+ Testing 에 대한 고심)

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -17,8 +17,12 @@ import Callout from '@/components/text/Callout';
 import NumberInput from '@/components/input/NumberInput';
 import { discountPercent } from '../discountPercent.util';
 import { CreateShuttleRouteFormValues } from './form.type';
-import { calculateUnion } from '../utils/calculateRoute';
-import { calculateRoute } from '../utils/calculateRoute';
+import {
+  calculateUnionTimes,
+  updateRouteFormValues,
+} from '../utils/calculateRoute';
+import { calculateRouteTimes } from '../utils/calculateRoute';
+import { RouteHubData } from '../utils/calculateRoute';
 
 interface Props {
   params: { eventId: string; dailyEventId: string };
@@ -201,20 +205,50 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
   };
 
   const handleCalculateRoute = useCallback(
-    async (type: 'toDestination' | 'fromDestination') => {
-      const hubsArray = getValues(
-        type === 'toDestination'
-          ? 'shuttleRouteHubsToDestination'
-          : 'shuttleRouteHubsFromDestination',
-      );
-      return calculateRoute(type, hubsArray, setValue, getValues);
+    async (hubsArray: RouteHubData[]) => {
+      if (
+        !confirm(
+          '경로 소요 시간을 계산하시겠습니까?\n경로 소요 시간은 `출발시간`을 기준으로 카카오 지도 길찾기 결과를 통해 계산됩니다.\n기존에 설정해두었던 나머지 경유지의 시간은 변경됩니다.',
+        )
+      )
+        return;
+      try {
+        const result = await calculateRouteTimes('fromDestination', hubsArray);
+        if (result) {
+          updateRouteFormValues('fromDestination', result, setValue);
+        }
+      } catch (error) {
+        alert(
+          '경로 소요 시간 계산 중 오류가 발생했습니다.\n' +
+            (error instanceof Error ? error.message : '알 수 없는 오류'),
+        );
+      }
     },
     [],
   );
 
-  const handleCalculateUnion = useCallback(async () => {
-    return calculateUnion(getValues, setValue);
-  }, []);
+  const handleCalculateUnion = useCallback(
+    async (hubsArray: RouteHubData[]) => {
+      if (
+        !confirm(
+          '경로 소요 시간을 계산하시겠습니까?\n경로 소요 시간은 `도착시간`을 기준으로 카카오 지도 길찾기 결과를 통해 계산됩니다.\n기존에 설정해두었던 나머지 경유지의 시간은 변경됩니다.',
+        )
+      )
+        return;
+      try {
+        const result = await calculateUnionTimes(hubsArray);
+        if (result) {
+          updateRouteFormValues('toDestination', result, setValue);
+        }
+      } catch (error) {
+        alert(
+          '경로 소요 시간 계산 중 오류가 발생했습니다.\n' +
+            (error instanceof Error ? error.message : '알 수 없는 오류'),
+        );
+      }
+    },
+    [],
+  );
 
   return (
     <main>
@@ -443,7 +477,11 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
               </button>
               <button
                 type="button"
-                onClick={handleCalculateUnion}
+                onClick={() =>
+                  handleCalculateUnion(
+                    getValues('shuttleRouteHubsToDestination'),
+                  )
+                }
                 className="ml-auto block text-14 text-green-500 underline underline-offset-2"
               >
                 경로 소요 시간 계산하기
@@ -561,7 +599,11 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
               </button>
               <button
                 type="button"
-                onClick={() => handleCalculateRoute('fromDestination')}
+                onClick={() =>
+                  handleCalculateRoute(
+                    getValues('shuttleRouteHubsFromDestination'),
+                  )
+                }
                 className="ml-auto block text-14 text-green-500 underline underline-offset-2"
               >
                 경로 소요 시간 계산하기

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/utils/calculateRoute.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/utils/calculateRoute.ts
@@ -4,7 +4,7 @@ import {
   roundDownToNearestFiveMinutes,
   roundUpToNearestFiveMinutes,
 } from './roundNearestFiveMinutes.util';
-import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
+import { UseFormSetValue } from 'react-hook-form';
 import { CreateShuttleRouteFormValues } from '../new/form.type';
 
 /**
@@ -19,258 +19,256 @@ export interface RouteHubData {
 }
 
 /**
- * calculateRoute 는 출발 시간 기준으로 경로를 계산하고 도착 시간을 설정합니다.
+ * calculateRouteTimes 는 출발 시간 기준으로 경유지 별 arrivalTime을 계산합니다.
  *
  * @param type 경로 계산 방향
  * @param hubsArray 경유지 배열
- * @param setValue
- * @param getValues
- * @return 도착 시간
+ * @return 계산된 경유지 배열
  */
-export const calculateRoute = async (
+export const calculateRouteTimes = async (
   type: 'toDestination' | 'fromDestination',
   hubsArray: RouteHubData[],
-  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
-  getValues: UseFormGetValues<CreateShuttleRouteFormValues>,
-): Promise<string | undefined> => {
+): Promise<RouteHubData[]> => {
   // 필수 데이터 유효성 검사
   const isInvalid = hubsArray.some((hub) => !hub.regionId || !hub.regionHubId);
 
   if (isInvalid || hubsArray.length < 2 || !hubsArray[0].arrivalTime) {
-    alert('모든 경유지의 지역, 정류장, 첫 정류장의 시간이 입력되어야 합니다.');
-    return;
+    throw new Error(
+      '모든 경유지의 지역, 정류장, 첫 정류장의 시간이 입력되어야 합니다.',
+    );
   }
 
-  try {
-    const origin = `${hubsArray[0].longitude},${hubsArray[0].latitude}`;
-    const destination = `${hubsArray[hubsArray.length - 1].longitude},${hubsArray[hubsArray.length - 1].latitude}`;
-    const waypoints = hubsArray
-      .slice(1, -1)
-      .map((hub) => `${hub.longitude},${hub.latitude}`)
-      .join('|');
-    const departureTime = dayjs(hubsArray[0].arrivalTime)
-      .tz('Asia/Seoul')
-      .format('YYYYMMDDHHmm'); // kakaomobility api 는 한국시간을 기준으로 받기에 한국시간으로 변환
+  const origin = `${hubsArray[0].longitude},${hubsArray[0].latitude}`;
+  const destination = `${hubsArray[hubsArray.length - 1].longitude},${hubsArray[hubsArray.length - 1].latitude}`;
+  const waypoints = hubsArray
+    .slice(1, -1)
+    .map((hub) => `${hub.longitude},${hub.latitude}`)
+    .join('|');
+  const departureTime = dayjs(hubsArray[0].arrivalTime)
+    .tz('Asia/Seoul')
+    .format('YYYYMMDDHHmm'); // kakaomobility api 는 한국시간을 기준으로 받기에 한국시간으로 변환
 
-    const res = await getEstimatedRoute({
-      origin,
-      destination,
-      waypoints,
-      departureTime,
-    });
+  const res = await getEstimatedRoute({
+    origin,
+    destination,
+    waypoints,
+    departureTime,
+  });
 
-    if (res.routes[0].result_code !== 0) {
-      throw new Error(res.routes[0].result_msg);
-    }
-
-    const result = res.routes.map((route) => ({
-      distance: route.summary.distance,
-      duration: route.summary.duration,
-      sections: route.sections.map((section) => ({
-        distance: section.distance,
-        duration: section.duration,
-      })),
-    }));
-
-    let currentTime = dayjs(hubsArray[0].arrivalTime);
-    hubsArray.forEach((_, index) => {
-      if (index === 0) return;
-
-      // 시간 추가 후 바로 5분 단위로 올림 처리
-      currentTime = roundUpToNearestFiveMinutes(
-        currentTime.add(result[0].sections[index - 1].duration, 'seconds'),
-      );
-
-      setValue(
-        type === 'toDestination'
-          ? `shuttleRouteHubsToDestination.${index}.arrivalTime`
-          : `shuttleRouteHubsFromDestination.${index}.arrivalTime`,
-        currentTime.toISOString(),
-      );
-    });
-
-    const destinationArrivalTime = getValues(
-      type === 'toDestination'
-        ? 'shuttleRouteHubsToDestination'
-        : 'shuttleRouteHubsFromDestination',
-    );
-    return destinationArrivalTime[hubsArray.length - 1].arrivalTime;
-  } catch (error) {
-    console.error('경로 계산 중 오류 발생:', error);
-    alert(
-      '경로 계산 중 오류가 발생했습니다.' +
-        (error instanceof Error && error.message),
-    );
-    return;
+  if (res.routes[0].result_code !== 0) {
+    throw new Error(res.routes[0].result_msg);
   }
+
+  const result = res.routes.map((route) => ({
+    distance: route.summary.distance,
+    duration: route.summary.duration,
+    sections: route.sections.map((section) => ({
+      distance: section.distance,
+      duration: section.duration,
+    })),
+  }));
+
+  let currentTime = dayjs(hubsArray[0].arrivalTime);
+  const calculatedHubsArray = hubsArray.map((_, index) => {
+    if (index === 0)
+      return {
+        ...hubsArray[index],
+        arrivalTime: currentTime.toISOString(),
+      };
+
+    // 시간 추가 후 바로 5분 단위로 올림 처리
+    currentTime = roundUpToNearestFiveMinutes(
+      currentTime.add(result[0].sections[index - 1].duration, 'seconds'),
+    );
+
+    return {
+      ...hubsArray[index],
+      arrivalTime: currentTime.toISOString(),
+    };
+  });
+
+  return calculatedHubsArray;
 };
 
 /**
- * calculateRouteBackward 는 도착 시간 기준으로 경로를 계산하고 출발 시간을 설정합니다.
+ * calculateRouteBackwardTimes 는 도착 시간을 기준으로 경유지 별 arrivalTime을 계산합니다.
  * api 에서 도착시간을 기준으로 계산해주지 않아, 호출자의 현재 시각을 기준으로 총 소요시간을 계산한뒤,
  * 도착시간에서 총 소요시간을 빼서 실제 출발 시간을 계산합니다.
  *
  * @param type 경로 계산 방향
  * @param hubsArray 경유지 배열
- * @param setValue
  * @return 출발 시간
  */
-export const calculateRouteBackward = async (
+export const calculateRouteBackwardTimes = async (
   type: 'toDestination' | 'fromDestination',
   hubsArray: RouteHubData[],
-  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
-): Promise<string | undefined> => {
+): Promise<RouteHubData[]> => {
   // 필수 데이터 유효성 검사
   const isInvalid = hubsArray.some((hub) => !hub.regionId || !hub.regionHubId);
 
   // 마지막 정류장(도착지)의 시간이 필요
   const lastIndex = hubsArray.length - 1;
   if (isInvalid || hubsArray.length < 2 || !hubsArray[lastIndex].arrivalTime) {
-    alert('모든 경유지의 지역, 정류장, 도착지의 시간이 입력되어야 합니다.');
-    return;
+    throw new Error(
+      '모든 경유지의 지역, 정류장, 도착지의 시간이 입력되어야 합니다.',
+    );
   }
 
-  try {
-    // 1. 임의의 출발 시간으로 API 호출하여 소요 시간 정보 확보
-    const origin = `${hubsArray[0].longitude},${hubsArray[0].latitude}`;
-    const destination = `${hubsArray[lastIndex].longitude},${hubsArray[lastIndex].latitude}`;
-    const waypoints = hubsArray
-      .slice(1, -1)
-      .map((hub) => `${hub.longitude},${hub.latitude}`)
-      .join('|');
+  // 1. 임의의 출발 시간으로 API 호출하여 소요 시간 정보 확보
+  const origin = `${hubsArray[0].longitude},${hubsArray[0].latitude}`;
+  const destination = `${hubsArray[lastIndex].longitude},${hubsArray[lastIndex].latitude}`;
+  const waypoints = hubsArray
+    .slice(1, -1)
+    .map((hub) => `${hub.longitude},${hub.latitude}`)
+    .join('|');
 
-    // 임의의 출발 시간
-    const tempDepartureTime = dayjs().format('YYYYMMDDHHmm'); // kakaomobility api 는 한국시간을 기준으로 받기에 한국시간으로 변환
+  // 임의의 출발 시간
+  const tempDepartureTime = dayjs().format('YYYYMMDDHHmm'); // kakaomobility api 는 한국시간을 기준으로 받기에 한국시간으로 변환
 
-    const res = await getEstimatedRoute({
-      origin,
-      destination,
-      waypoints,
-      departureTime: tempDepartureTime,
-    });
+  const res = await getEstimatedRoute({
+    origin,
+    destination,
+    waypoints,
+    departureTime: tempDepartureTime,
+  });
 
-    if (res.routes[0].result_code !== 0) {
-      throw new Error(res.routes[0].result_msg);
-    }
-
-    const result = res.routes[0];
-    const totalDuration = result.summary.duration; // 총 소요 시간(초)
-
-    // 2. 도착 시간에서 총 소요 시간을 빼서 실제 출발 시간 계산
-    const arrivalTime = dayjs(hubsArray[lastIndex].arrivalTime).tz(
-      'Asia/Seoul',
-    );
-    const actualDepartureTime = arrivalTime.subtract(totalDuration, 'second');
-
-    const roundedActualDepartureTime =
-      roundDownToNearestFiveMinutes(actualDepartureTime);
-
-    // 3. 출발 시간 설정
-    setValue(
-      type === 'toDestination'
-        ? `shuttleRouteHubsToDestination.0.arrivalTime`
-        : `shuttleRouteHubsFromDestination.0.arrivalTime`,
-      roundedActualDepartureTime.toISOString(),
-    );
-
-    // 4. 각 경유지 시간 계산
-    let currentTime = actualDepartureTime;
-    for (let i = 1; i < hubsArray.length; i++) {
-      if (i < result.sections.length) {
-        // 시간 추가 후 바로 5분 단위로 올림 처리
-        currentTime = roundUpToNearestFiveMinutes(
-          currentTime.add(result.sections[i - 1].duration, 'second'),
-        );
-
-        // 중간 경유지 시간 설정 (마지막은 이미 설정되어 있음)
-        if (i < lastIndex) {
-          setValue(
-            type === 'toDestination'
-              ? `shuttleRouteHubsToDestination.${i}.arrivalTime`
-              : `shuttleRouteHubsFromDestination.${i}.arrivalTime`,
-            currentTime.toISOString(),
-          );
-        }
-      }
-    }
-
-    return roundedActualDepartureTime.toISOString();
-  } catch (error) {
-    console.error('경로 계산 중 오류 발생:', error);
-    alert(
-      '경로 계산 중 오류가 발생했습니다.' +
-        (error instanceof Error && error.message),
-    );
-    return;
+  if (res.routes[0].result_code !== 0) {
+    throw new Error(res.routes[0].result_msg);
   }
+
+  const result = res.routes[0];
+  const totalDuration = result.summary.duration; // 총 소요 시간(초)
+
+  // 2. 도착 시간에서 총 소요 시간을 빼서 실제 출발 시간 계산
+  const lastHubArrivalTime = dayjs(hubsArray[lastIndex].arrivalTime).tz(
+    'Asia/Seoul',
+  );
+  const actualDepartureTime = lastHubArrivalTime.subtract(
+    totalDuration,
+    'second',
+  );
+
+  const roundedActualDepartureTime =
+    roundDownToNearestFiveMinutes(actualDepartureTime);
+
+  // 4. 각 경유지 시간 계산
+  let currentTime = actualDepartureTime;
+  const calculatedHubsArray = hubsArray.map((_, index) => {
+    if (index === 0)
+      return {
+        ...hubsArray[index],
+        arrivalTime: roundedActualDepartureTime.toISOString(),
+      };
+
+    if (index < result.sections.length) {
+      // 시간 추가 후 바로 5분 단위로 올림 처리
+      currentTime = roundUpToNearestFiveMinutes(
+        currentTime.add(result.sections[index - 1].duration, 'second'),
+      );
+
+      return {
+        ...hubsArray[index],
+        arrivalTime: currentTime.toISOString(),
+      };
+    }
+
+    return {
+      ...hubsArray[index],
+      arrivalTime: lastHubArrivalTime.toISOString(),
+    };
+  });
+
+  return calculatedHubsArray;
 };
 
 /**
- * calculateUnion 는 출발시간과 도착시간을 모두 고려하여 경로를 계산합니다.
- * calculateRouteBackward와 calculateRoute를 순차적으로 호출하여 경로 소요시간을 계산합니다.
+ * calculateUnionTimes 는 출발시간과 도착시간을 모두 고려하여 경로를 계산합니다.
+ * calculateRouteBackwardTimes와 calculateRouteTimes를 순차적으로 호출하여 경로 소요시간을 계산합니다.
  * 설정한 도착시간과 10분이상 차이나게되면 출발시간을 시간 차 만큼 보상하여 경로를 재계산합니다.
  *
- * @param getValues
- * @param setValue
- * @return void
+ * @param hubsArray 경유지 배열
+ * @return 계산된 시간 배열
  */
-export const calculateUnion = async (
-  getValues: UseFormGetValues<CreateShuttleRouteFormValues>,
-  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
-): Promise<void> => {
-  const hubsArray = getValues('shuttleRouteHubsToDestination');
+export const calculateUnionTimes = async (
+  hubsArray: RouteHubData[],
+): Promise<RouteHubData[]> => {
   const plannedArrivalTime = hubsArray[hubsArray.length - 1].arrivalTime;
 
   try {
     // 1. 도착 시간 기준으로 출발 시간 계산
-    const estimatedDepartureTime = await calculateRouteBackward(
-      'toDestination',
-      hubsArray,
-      setValue,
-    );
+    const resultOfCalculateRouteBackwardTimes =
+      await calculateRouteBackwardTimes('toDestination', hubsArray);
 
-    // 2. 출발 시간 기준으로 도착 시간 계산
-    const estimatedDestinationArrivalTime = await calculateRoute(
-      'toDestination',
-      hubsArray,
-      setValue,
-      getValues,
-    );
-
-    if (!estimatedDepartureTime || !estimatedDestinationArrivalTime) {
-      throw new Error(
-        '경로 계산에 필요한 시간 정보가 누락되었습니다. 각 정류장의 위치와 시간을 다시 확인해주세요.',
-      );
+    if (!resultOfCalculateRouteBackwardTimes) {
+      throw new Error('경로 계산 중 오류가 발생했습니다.');
     }
 
-    // 3. 예상 도착 시간과 계획된 도착 시간 비교
-    const diff = dayjs(estimatedDestinationArrivalTime).diff(
-      estimatedDepartureTime,
+    // 2. 출발 시간 기준으로 도착 시간 계산
+    const resultOfCalculateRouteTimes = await calculateRouteTimes(
+      'toDestination',
+      resultOfCalculateRouteBackwardTimes,
+    );
+
+    if (!resultOfCalculateRouteTimes) {
+      throw new Error('경로 계산 중 오류가 발생했습니다.');
+    }
+
+    const arrivalTimeDifference = dayjs(plannedArrivalTime).diff(
+      resultOfCalculateRouteTimes[hubsArray.length - 1].arrivalTime,
       'minute',
     );
 
-    if (diff >= 10) {
-      const arrivalTimeDifference = dayjs(plannedArrivalTime).diff(
-        estimatedDestinationArrivalTime,
-        'minute',
-      );
-      setValue(
-        'shuttleRouteHubsToDestination.0.arrivalTime',
-        dayjs(getValues('shuttleRouteHubsToDestination.0.arrivalTime'))
+    if (Math.abs(arrivalTimeDifference) >= 10) {
+      let newDepartureTime;
+      if (arrivalTimeDifference > 0) {
+        newDepartureTime = dayjs(
+          resultOfCalculateRouteBackwardTimes[0].arrivalTime,
+        )
           .add(arrivalTimeDifference, 'minute')
-          .toISOString(),
-      );
-      await calculateRoute(
-        'toDestination',
-        getValues('shuttleRouteHubsToDestination'),
-        setValue,
-        getValues,
-      );
+          .toISOString();
+      } else {
+        newDepartureTime = dayjs(
+          resultOfCalculateRouteBackwardTimes[0].arrivalTime,
+        )
+          .subtract(Math.abs(arrivalTimeDifference), 'minute')
+          .toISOString();
+      }
+
+      const newHubsArray = [...hubsArray];
+      newHubsArray[0].arrivalTime = newDepartureTime;
+
+      const newEstimatedDestinationArrivalTimeResult =
+        await calculateRouteTimes('toDestination', newHubsArray);
+
+      return newEstimatedDestinationArrivalTimeResult;
     }
+
+    return resultOfCalculateRouteTimes;
   } catch (error) {
-    console.error('경로 계산 통합 중 오류 발생:', error);
-    alert(
-      `경로 계산 통합 중 오류가 발생했습니다: ${error instanceof Error && error.message}`,
+    throw new Error(
+      `경로 계산 통합 중 오류가 발생했습니다: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
     );
   }
+};
+
+/**
+ * updateRouteFormValues 는 계산된 시간 정보로 폼 값을 업데이트합니다.
+ *
+ * @param type 경로 계산 방향
+ * @param calculatedTimes 계산된 시간 배열
+ * @param setValue
+ */
+export const updateRouteFormValues = (
+  type: 'toDestination' | 'fromDestination',
+  calculatedTimes: RouteHubData[],
+  setValue: UseFormSetValue<CreateShuttleRouteFormValues>,
+) => {
+  calculatedTimes.forEach((hub, index) => {
+    setValue(
+      type === 'toDestination'
+        ? `shuttleRouteHubsToDestination.${index}.arrivalTime`
+        : `shuttleRouteHubsFromDestination.${index}.arrivalTime`,
+      hub.arrivalTime,
+    );
+  });
 };


### PR DESCRIPTION
## 개요
calculateRoute.ts(자동 경로 소요시간 계산) 를 개선하였습니다.

## 변경사항
- 가는 편에서필요한 폼을 채우지 않았을 경우 alert가 3번 -> 1번 표시되도록 변경하였습니다.
- 가는 편에서 자동 경로 소요시간을 계산했을때 절대값인 10분이상 차이가 날때도 처리되도록 변경하였습니니다.
- 응집성을 높이고, 결합도를 낮추는 방향으로 코드를 개선하였습니다.
  - 기존의 코드는 계산과 상태 업데이트라는 두 가지 책임을 가지고 있어 단일 책임 원칙(SRP)에 위배되었습니다. 함수는 하나의 명확한 책임을 가지도록 변경하고자 합니다..
  - 또, 계산함수에 react-hook-form의 setValue와 getValues에 높은 의존성을 지니고 있었습니다. 이를 개선하고자 합니다.

#### 테스트 코드 관련
- jest + React Testing Library 를 활용한 단위/통합테스트를 고려하고 있었습니다. (Playwright, Cypress 와 같은 e2e 테스트는 QA팀이 없는 상황에서 도입해볼만 하지만, 다른 종류의 테스트에 비해 비용이 제일 많이 들고 변경사항이 발생하면 테스트코드가 쉽게 깨지는 단점이 있습니다.)
- 가장 비용이 낮은 unit 테스트에서는 아주 빠르고 간단하게 적용이 가능했습니다. 
- 다만, 코드 변경에도 테스트 코드가 깨지지 않는 통합테스트까지 반영되어야 효능이 있을 것이라고 생각했는데요. 노선 수정 페이지에서 사용하려 시도해보니 쉽게 적용할 수는 없었습니다. 알 수 없는 오류를 디버깅하는데만 생각보다 많은 시간이 소요됐고, 테스트 코드를 작성하는 비용도 적진 않았습니다. 
- 궁극적으로는 테스트 코드를 익숙하게 사용하는 상황에서는 개발 비용을 절감할 수 있을것으로 기대하고 있습니다. 다만 그 전까지는 프로덕트에 바로 적용하긴 어려워 보여요. 개인 시간을 활용해서 지속적으로 알아볼 예정인데, 추후 소식 업데이트 드리겠습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).