### PR TITLE
fix: 경로소요시간 계산하기 

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -206,16 +206,15 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
   const handleCalculateRoute = useCallback(
     async (hubsArray: RouteHubData[]) => {
-      if (
-        !confirm(
-          '경로 소요 시간을 계산하시겠습니까?\n경로 소요 시간은 `출발시간`을 기준으로 카카오 지도 길찾기 결과를 통해 계산됩니다.\n기존에 설정해두었던 나머지 경유지의 시간은 변경됩니다.',
-        )
-      )
-        return;
+      const userConfirmed = confirm(
+        '경로 소요 시간을 계산하시겠습니까?\n경로 소요 시간은 `출발시간`을 기준으로 카카오 지도 길찾기 결과를 통해 계산됩니다.\n기존에 설정해두었던 나머지 경유지의 시간은 변경됩니다.',
+      );
+      if (!userConfirmed) return;
       try {
         const result = await calculateRouteTimes('fromDestination', hubsArray);
         if (result) {
           updateRouteFormValues('fromDestination', result, setValue);
+          alert('경로 소요 시간 계산이 완료되었습니다.');
         }
       } catch (error) {
         alert(
@@ -229,16 +228,15 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
   const handleCalculateUnion = useCallback(
     async (hubsArray: RouteHubData[]) => {
-      if (
-        !confirm(
-          '경로 소요 시간을 계산하시겠습니까?\n경로 소요 시간은 `도착시간`을 기준으로 카카오 지도 길찾기 결과를 통해 계산됩니다.\n기존에 설정해두었던 나머지 경유지의 시간은 변경됩니다.',
-        )
-      )
-        return;
+      const userConfirmed = confirm(
+        '경로 소요 시간을 계산하시겠습니까?\n경로 소요 시간은 `도착시간`을 기준으로 카카오 지도 길찾기 결과를 통해 계산됩니다.\n기존에 설정해두었던 나머지 경유지의 시간은 변경됩니다.',
+      );
+      if (!userConfirmed) return;
       try {
         const result = await calculateUnionTimes(hubsArray);
         if (result) {
           updateRouteFormValues('toDestination', result, setValue);
+          alert('경로 소요 시간 계산이 완료되었습니다.');
         }
       } catch (error) {
         alert(

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/utils/calculateRoute.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/utils/calculateRoute.ts
@@ -223,19 +223,16 @@ export const calculateUnionTimes = async (
       if (arrivalTimeDifference > 0) {
         newDepartureTime = dayjs(
           resultOfCalculateRouteBackwardTimes[0].arrivalTime,
-        )
-          .add(arrivalTimeDifference, 'minute')
-          .toISOString();
+        ).add(arrivalTimeDifference, 'minute');
       } else {
         newDepartureTime = dayjs(
           resultOfCalculateRouteBackwardTimes[0].arrivalTime,
-        )
-          .subtract(Math.abs(arrivalTimeDifference), 'minute')
-          .toISOString();
+        ).subtract(Math.abs(arrivalTimeDifference), 'minute');
       }
 
       const newHubsArray = [...hubsArray];
-      newHubsArray[0].arrivalTime = newDepartureTime;
+      newHubsArray[0].arrivalTime =
+        roundDownToNearestFiveMinutes(newDepartureTime).toISOString();
 
       const newEstimatedDestinationArrivalTimeResult =
         await calculateRouteTimes('toDestination', newHubsArray);


### PR DESCRIPTION
## 개요
- alert 클릭 안되던 이슈, 가는편-출발지의 시각이 5분 내림 적용이 안되던 이슈를 해결하였습니다.
- 경로소요시간이 완료되었을때 완료되었다는 확인 alert를 표시합니다.

## 변경사항
if 의 조건문에 confirm 을 사용하면 브라우저 대화창의 클릭이벤트가 씹힐 수 있습니다.
이를 confirm 을 변수 저장하는 방법으로 해결하였습니다. 왜 이것이 문제해결이 도움이 되는지 이해하지 못하였습니다 (혹시 아시나요?)

추측되는 원인은 아래와 같아요... (sonnet-3.7) 자세한 내용은 추후 issue 에서 다뤄볼게요.

#### 비동기 처리와 상태 업데이트 타이밍 문제
React에서 상태 업데이트는 비동기적으로 일어나며, 일반적으로 이벤트 핸들러가 완료된 후에 일괄 처리됩니다.
타이밍 불일치 원인:
confirm() 호출은 JavaScript 실행을 일시 중단시키고, 사용자 응답을 기다립니다
이 중단 시점에서 React는 아직 상태 업데이트를 처리하지 않았을 수 있습니다
조건문이 실행될 때, 상태는 아직 이전 값을 유지하고 있을 가능성이 높습니다
결과적으로 confirm 응답과 상태 업데이트 사이에 '경쟁 상태(race condition)'가 발생할 수 있습니다

#### 이벤트 버블링과 캡처링 관련 문제
브라우저의 이벤트 시스템은 이벤트 버블링(하위 요소에서 상위 요소로)과 캡처링(상위 요소에서 하위 요소로) 단계로 작동합니다.
처리 오류 원인:
confirm() 다이얼로그가 표시되면 진행 중이던 이벤트 흐름이 중단됩니다
사용자가 응답한 후, 원래 진행 중이던 이벤트 처리가 계속됩니다
이 시점에서 React의 합성 이벤트 시스템과 브라우저의 네이티브 이벤트 처리가 동기화되지 않을 수 있습니다
특히 여러 이벤트 핸들러가 중첩되어 있거나 부모-자식 컴포넌트 간 이벤트 전파가 있는 경우 문제가 복잡해집니다


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).