### PR TITLE
feat: 장소 태그 추가

### DIFF
--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/form.type.ts
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/form.type.ts
@@ -9,8 +9,6 @@ export const EditHubFormSchema = z.object({
     latitude: z.number(),
     longitude: z.number(),
   }),
-  eventDestination: z.boolean(),
-  shuttleHub: z.boolean(),
 });
 
 export type EditHubFormType = z.infer<typeof EditHubFormSchema>;

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/form.type.ts
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/form.type.ts
@@ -9,6 +9,8 @@ export const EditHubFormSchema = z.object({
     latitude: z.number(),
     longitude: z.number(),
   }),
+  eventDestination: z.boolean(),
+  shuttleHub: z.boolean(),
 });
 
 export type EditHubFormType = z.infer<typeof EditHubFormSchema>;

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -20,12 +20,14 @@ import { RegionHub } from '@/types/hub.type';
 import MapGuidesAtNewEditPage from '@/app/locations/components/MapGuidesAtNewEditPage';
 import Toggle from '@/components/button/Toggle';
 import { putShuttleStop } from '@/services/shuttleStops.service';
+import { TagStates } from '@/app/locations/new/page';
+import { getTags } from '@/app/locations/utils/getTags.util';
 
-const EditHubPage = ({
-  params,
-}: {
+interface Props {
   params: { regionId: string; hubId: string };
-}) => {
+}
+
+const EditHubPage = ({ params }: Props) => {
   const {
     data: regions,
     isPending: isRegionsPending,
@@ -59,18 +61,12 @@ interface EditFormProps {
   hub: RegionHub;
 }
 
-interface TagStates {
-  isEventDestination: boolean;
-  isShuttleHub: boolean;
-}
-
 const EditForm = ({ regions, hub }: EditFormProps) => {
   const router = useRouter();
   const [tagStates, setTagStates] = useState<TagStates>({
     isEventDestination: hub.eventDestination,
     isShuttleHub: hub.shuttleHub,
   });
-  console.log(tagStates);
   const defaultValues = {
     regionId: hub.regionId,
     name: hub.name,
@@ -112,13 +108,6 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
     }));
   };
 
-  const getTags = useCallback(() => {
-    const tags: ('EVENT_DESTINATION' | 'SHUTTLE_HUB')[] = [];
-    if (tagStates.isEventDestination) tags.push('EVENT_DESTINATION');
-    if (tagStates.isShuttleHub) tags.push('SHUTTLE_HUB');
-    return tags;
-  }, [tagStates]);
-
   const onSubmit = useCallback(
     async (data: EditHubFormType) => {
       const target = regions?.find((r) => r.regionId === data.regionId);
@@ -134,13 +123,13 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
         });
         await putShuttleStop({
           regionHubId: hub.regionHubId,
-          types: getTags(),
+          types: getTags(tagStates),
         });
         alert('장소가 수정되었습니다.');
         router.push('/locations');
       }
     },
-    [recommended, router, regions, getTags],
+    [recommended, router, regions, tagStates],
   );
 
   return (

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -20,7 +20,7 @@ import { RegionHub } from '@/types/hub.type';
 import MapGuidesAtNewEditPage from '@/app/locations/components/MapGuidesAtNewEditPage';
 import Toggle from '@/components/button/Toggle';
 import { putShuttleStop } from '@/services/shuttleStops.service';
-import { TagStates } from '@/app/locations/new/page';
+import { TagStates } from '@/app/locations/location.type';
 import { getTags } from '@/app/locations/utils/getTags.util';
 
 interface Props {

--- a/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
+++ b/src/app/locations/[regionId]/hubs/[hubId]/edit/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 import { conform, type EditHubFormType } from './form.type';
 import Input from '@/components/input/Input';
@@ -18,6 +18,8 @@ import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
 import { RegionHub } from '@/types/hub.type';
 import MapGuidesAtNewEditPage from '@/app/locations/components/MapGuidesAtNewEditPage';
+import Toggle from '@/components/button/Toggle';
+import { putShuttleStop } from '@/services/shuttleStops.service';
 
 const EditHubPage = ({
   params,
@@ -57,9 +59,18 @@ interface EditFormProps {
   hub: RegionHub;
 }
 
+interface TagStates {
+  isEventDestination: boolean;
+  isShuttleHub: boolean;
+}
+
 const EditForm = ({ regions, hub }: EditFormProps) => {
   const router = useRouter();
-
+  const [tagStates, setTagStates] = useState<TagStates>({
+    isEventDestination: hub.eventDestination,
+    isShuttleHub: hub.shuttleHub,
+  });
+  console.log(tagStates);
   const defaultValues = {
     regionId: hub.regionId,
     name: hub.name,
@@ -87,33 +98,49 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
     ).at(0);
   }, [regions, address]);
 
-  const { mutate: putHub } = usePutRegionHub({
-    onSuccess: () => {
-      alert('장소가 수정되었습니다.');
-      router.push('/locations');
-    },
+  const { mutateAsync: putHub } = usePutRegionHub({
     onError: (error) => {
       alert(`장소 수정에 실패했습니다.`);
       console.error(error);
     },
   });
 
+  const handleTagToggle = (key: keyof TagStates) => {
+    setTagStates((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  const getTags = useCallback(() => {
+    const tags: ('EVENT_DESTINATION' | 'SHUTTLE_HUB')[] = [];
+    if (tagStates.isEventDestination) tags.push('EVENT_DESTINATION');
+    if (tagStates.isShuttleHub) tags.push('SHUTTLE_HUB');
+    return tags;
+  }, [tagStates]);
+
   const onSubmit = useCallback(
-    (data: EditHubFormType) => {
+    async (data: EditHubFormType) => {
       const target = regions?.find((r) => r.regionId === data.regionId);
       const confirmMessage =
         recommended?.regionId === data.regionId || false
           ? `장소를 수정하시겠습니까?`
           : `선택한 주소 "${data.coord.address}"가 지역 "${target ? `${target.provinceFullName} ${target.cityFullName}` : '<오류: 알수 없는 위치>'}에 등록됩니다. 장소를 수정하시겠습니까?`;
       if (confirm(confirmMessage)) {
-        putHub({
+        await putHub({
           regionId: data.regionId,
           regionHubId: hub.regionHubId,
           body: conform(data),
         });
+        await putShuttleStop({
+          regionHubId: hub.regionHubId,
+          types: getTags(),
+        });
+        alert('장소가 수정되었습니다.');
+        router.push('/locations');
       }
     },
-    [recommended, router, regions],
+    [recommended, router, regions, getTags],
   );
 
   return (
@@ -163,6 +190,21 @@ const EditForm = ({ regions, hub }: EditFormProps) => {
               </div>
             )}
           />
+        </Form.section>
+        <Form.section>
+          <Form.label>태그 선택</Form.label>
+          <div className="flex flex-row gap-4">
+            <Toggle
+              label="행사장소"
+              value={tagStates.isEventDestination}
+              setValue={() => handleTagToggle('isEventDestination')}
+            />
+            <Toggle
+              label="정류장"
+              value={tagStates.isShuttleHub}
+              setValue={() => handleTagToggle('isShuttleHub')}
+            />
+          </div>
         </Form.section>
         <Form.submitButton>수정하기</Form.submitButton>
       </Form>

--- a/src/app/locations/components/RegionHubFilter.tsx
+++ b/src/app/locations/components/RegionHubFilter.tsx
@@ -11,6 +11,7 @@ import DebouncedInput from '@/components/input/DebouncedInput';
 import { GetRegionHubsOptions } from '@/services/hub.service';
 import { RegionHubFilterAction } from '../hooks/useRegionHubFilter';
 import RegionInput from '@/components/input/RegionInput';
+import Toggle from '@/components/button/Toggle';
 
 interface Props {
   option: GetRegionHubsOptions;
@@ -57,6 +58,45 @@ const RegionHubFilter = ({ option, dispatch }: Props) => {
                 })
               }
             />
+          </article>
+          <article>
+            <Label>태그</Label>
+            <div className="flex flex-row gap-4">
+              <Toggle
+                label={'행사장'}
+                value={option.usageType?.includes('EVENT_DESTINATION') ?? false}
+                setValue={() => {
+                  const newUsageType = option.usageType?.includes(
+                    'EVENT_DESTINATION',
+                  )
+                    ? option.usageType?.filter(
+                        (type) => type !== 'EVENT_DESTINATION',
+                      )
+                    : [...(option.usageType ?? []), 'EVENT_DESTINATION'];
+
+                  dispatch({
+                    type: 'SET_USAGE_TYPE',
+                    usageType:
+                      newUsageType.length > 0 ? newUsageType : undefined,
+                  });
+                }}
+              />
+              <Toggle
+                label={'정류장'}
+                value={option.usageType?.includes('SHUTTLE_HUB') ?? false}
+                setValue={() => {
+                  const newUsageType = option.usageType?.includes('SHUTTLE_HUB')
+                    ? option.usageType?.filter((type) => type !== 'SHUTTLE_HUB')
+                    : [...(option.usageType ?? []), 'SHUTTLE_HUB'];
+
+                  dispatch({
+                    type: 'SET_USAGE_TYPE',
+                    usageType:
+                      newUsageType.length > 0 ? newUsageType : undefined,
+                  });
+                }}
+              />
+            </div>
           </article>
         </section>
       </DisclosurePanel>

--- a/src/app/locations/hooks/useRegionHubFilter.tsx
+++ b/src/app/locations/hooks/useRegionHubFilter.tsx
@@ -13,6 +13,7 @@ export default useRegionHubFilter;
 const EMPTY_REGION_HUB_FILTER: GetRegionHubsOptions = {
   regionId: undefined,
   name: undefined,
+  usageType: undefined,
 };
 
 export type RegionHubFilterAction =
@@ -23,6 +24,10 @@ export type RegionHubFilterAction =
   | {
       type: 'SET_NAME';
       name: GetRegionHubsOptions['name'];
+    }
+  | {
+      type: 'SET_USAGE_TYPE';
+      usageType: GetRegionHubsOptions['usageType'];
     }
   | {
       type: 'RESET';
@@ -43,10 +48,13 @@ const reducer = (
         ...prevState,
         name: action.name,
       };
-    case 'RESET':
+    case 'SET_USAGE_TYPE':
       return {
-        ...EMPTY_REGION_HUB_FILTER,
+        ...prevState,
+        usageType: action.usageType,
       };
+    case 'RESET':
+      return EMPTY_REGION_HUB_FILTER;
     default:
       console.error('Unknown action type', action);
       return prevState;

--- a/src/app/locations/location.type.ts
+++ b/src/app/locations/location.type.ts
@@ -1,0 +1,4 @@
+export interface TagStates {
+  isEventDestination: boolean;
+  isShuttleHub: boolean;
+}

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -14,13 +14,14 @@ import Heading from '@/components/text/Heading';
 import Form from '@/components/form/Form';
 import MapGuidesAtNewEditPage from '../components/MapGuidesAtNewEditPage';
 import Toggle from '@/components/button/Toggle';
-import { postShuttleStop } from '@/services/shuttleStops.service';
+import { putShuttleStop } from '@/services/shuttleStops.service';
+import { getTags } from '../utils/getTags.util';
 
 interface Props {
   searchParams: { latitude: string; longitude: string; address: string };
 }
 
-interface TagStates {
+export interface TagStates {
   isEventDestination: boolean;
   isShuttleHub: boolean;
 }
@@ -77,15 +78,15 @@ const NewHubPage = ({ searchParams }: Props) => {
           regionId: data.regionId,
           body: conform(data),
         });
-        await postShuttleStop({
+        await putShuttleStop({
           regionHubId: res.regionHubId,
-          type: 'SHUTTLE_HUB',
+          types: getTags(tagStates),
         });
         alert('장소가 추가되었습니다.');
         router.push('/locations');
       }
     },
-    [recommended, router, regions],
+    [recommended, router, regions, tagStates],
   );
 
   const handleTagToggle = (key: keyof TagStates) => {

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -16,14 +16,10 @@ import MapGuidesAtNewEditPage from '../components/MapGuidesAtNewEditPage';
 import Toggle from '@/components/button/Toggle';
 import { putShuttleStop } from '@/services/shuttleStops.service';
 import { getTags } from '../utils/getTags.util';
+import { TagStates } from '../location.type';
 
 interface Props {
   searchParams: { latitude: string; longitude: string; address: string };
-}
-
-export interface TagStates {
-  isEventDestination: boolean;
-  isShuttleHub: boolean;
 }
 
 const NewHubPage = ({ searchParams }: Props) => {

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -59,12 +59,7 @@ const NewHubPage = ({ searchParams }: Props) => {
     ).at(0);
   }, [regions, address]);
 
-  const { mutateAsync: addHub } = usePostRegionHub({
-    onError: (error) => {
-      alert(`장소 추가에 실패했습니다.`);
-      console.error(error);
-    },
-  });
+  const { mutateAsync: addHub } = usePostRegionHub();
 
   const onSubmit = useCallback(
     async (data: CreateHubFormType) => {
@@ -74,16 +69,21 @@ const NewHubPage = ({ searchParams }: Props) => {
           ? `장소를 추가하시겠습니까?`
           : `선택한 주소 "${data.coord.address}"가 지역 "${target ? `${target.provinceFullName} ${target.cityFullName}` : '<오류: 알수 없는 위치>'}에 등록됩니다. 장소를 추가하시겠습니까?`;
       if (confirm(confirmMessage)) {
-        const res = await addHub({
-          regionId: data.regionId,
-          body: conform(data),
-        });
-        await putShuttleStop({
-          regionHubId: res.regionHubId,
-          types: getTags(tagStates),
-        });
-        alert('장소가 추가되었습니다.');
-        router.push('/locations');
+        try {
+          const res = await addHub({
+            regionId: data.regionId,
+            body: conform(data),
+          });
+          await putShuttleStop({
+            regionHubId: res.regionHubId,
+            types: getTags(tagStates),
+          });
+          alert('장소가 추가되었습니다.');
+          router.push('/locations');
+        } catch (error) {
+          alert('장소 추가에 실패했습니다.');
+          console.error(error);
+        }
       }
     },
     [recommended, router, regions, tagStates],

--- a/src/app/locations/table.type.tsx
+++ b/src/app/locations/table.type.tsx
@@ -12,6 +12,28 @@ export const columns = [
     header: () => '이름',
     cell: (info) => info.getValue(),
   }),
+  columnHelper.display({
+    id: 'tags',
+    header: () => '태그',
+    cell: (info) => {
+      const eventDestination = info.row.original.eventDestination;
+      const shuttleHub = info.row.original.shuttleHub;
+      return (
+        <div className="flex flex-col gap-4">
+          {eventDestination && (
+            <span className="py-2 rounded-xl bg-green-50 px-4 text-center text-14 font-500 text-green-500">
+              행사장
+            </span>
+          )}
+          {shuttleHub && (
+            <span className="py-2 rounded-xl bg-blue-50 px-4 text-center text-14 font-500 text-blue-500">
+              정류장
+            </span>
+          )}
+        </div>
+      );
+    },
+  }),
   columnHelper.accessor('regionId', {
     header: () => '지역',
     cell: (info) => {

--- a/src/app/locations/utils/getTags.util.ts
+++ b/src/app/locations/utils/getTags.util.ts
@@ -1,0 +1,8 @@
+import { TagStates } from '@/app/locations/new/page';
+
+export const getTags = (tagStates: TagStates) => {
+  const tags: ('EVENT_DESTINATION' | 'SHUTTLE_HUB')[] = [];
+  if (tagStates.isEventDestination) tags.push('EVENT_DESTINATION');
+  if (tagStates.isShuttleHub) tags.push('SHUTTLE_HUB');
+  return tags;
+};

--- a/src/app/locations/utils/getTags.util.ts
+++ b/src/app/locations/utils/getTags.util.ts
@@ -1,4 +1,4 @@
-import { TagStates } from '@/app/locations/new/page';
+import { TagStates } from '../location.type';
 
 export const getTags = (tagStates: TagStates) => {
   const tags: ('EVENT_DESTINATION' | 'SHUTTLE_HUB')[] = [];

--- a/src/components/button/Toggle.tsx
+++ b/src/components/button/Toggle.tsx
@@ -19,12 +19,13 @@ const Toggle = ({ disabled, value, setValue, label, onClick }: Props) => {
   return (
     <button
       className={twJoin(
-        'font-500 text-14 rounded-xl px-8 py-4 active:scale-90 transition-all border border-blue-100 hover:border-blue-600 flex flex-row items-center justify-start',
-        'disabled:opacity-50 disabled:cursor-not-allowed',
+        'flex flex-row items-center justify-start rounded-xl border border-blue-100 px-8 py-4 text-14 font-500 transition-all hover:border-blue-600 active:scale-90',
+        'disabled:cursor-not-allowed disabled:opacity-50',
         value ? 'bg-blue-400 text-white' : 'bg-neutral-50',
       )}
       onClick={onClick ?? (setValue && (() => setValue((prev) => !prev)))}
       disabled={disabled}
+      type="button"
     >
       {value ? <CheckIcon size={18} /> : <XIcon size={18} />} {label}
     </button>

--- a/src/services/hub.service.ts
+++ b/src/services/hub.service.ts
@@ -36,6 +36,7 @@ export const useGetRegions = () => {
 export interface GetRegionHubsOptions {
   regionId?: string;
   name?: string;
+  usageType?: string[];
   orderBy?: 'name' | 'address' | 'latitude' | 'longitude';
   order?: 'ASC' | 'DESC';
 }

--- a/src/services/hub.service.ts
+++ b/src/services/hub.service.ts
@@ -17,8 +17,9 @@ import regions from '../data/regions.json';
 import { RegionSchema } from '@/types/region.type';
 import { toSearchParamString } from '@/utils/searchParam.util';
 import { withPagination } from '@/types/common.type';
+import { z } from 'zod';
 
-// ----- 조회 -----
+// ----- GET -----
 
 // 실제 API 호출이 아니고 데이터 객체를 불러옴
 export const getRegions = () => {
@@ -124,7 +125,7 @@ export const useGetRegionHub = (regionId: string, regionHubId: string) => {
   });
 };
 
-// ----- 명령 -----
+// ----- POST -----
 
 export const postRegionHub = async (
   regionId: string,
@@ -133,6 +134,11 @@ export const postRegionHub = async (
   return await authInstance.post(
     `/v1/location/admin/regions/${regionId}/hubs`,
     silentParse(CreateHubRequestSchema, body),
+    {
+      shape: {
+        regionHubId: z.string(),
+      },
+    },
   );
 };
 
@@ -166,6 +172,11 @@ export const putRegionHub = async (
   return await authInstance.put(
     `/v1/location/admin/regions/${regionId}/hubs/${regionHubId}`,
     body,
+    {
+      shape: {
+        regionHubId: z.string(),
+      },
+    },
   );
 };
 

--- a/src/services/hub.service.ts
+++ b/src/services/hub.service.ts
@@ -173,11 +173,6 @@ export const putRegionHub = async (
   return await authInstance.put(
     `/v1/location/admin/regions/${regionId}/hubs/${regionHubId}`,
     body,
-    {
-      shape: {
-        regionHubId: z.string(),
-      },
-    },
   );
 };
 

--- a/src/services/shuttleStops.service.ts
+++ b/src/services/shuttleStops.service.ts
@@ -2,8 +2,6 @@ import { silentParse } from '@/utils/parse.util';
 import { authInstance } from './config';
 import {
   AdminCreateShuttleStopRequest,
-  AdminDeleteShuttleStopRequest,
-  AdminDeleteShuttleStopRequestSchema,
   AdminSaveShuttleStopTagRequest,
   AdminSaveShuttleStopTagRequestSchema,
 } from '@/types/shuttleStop.type';
@@ -15,17 +13,6 @@ export const postShuttleStop = async (data: AdminCreateShuttleStopRequest) => {
   await authInstance.post(
     '/v1/shuttle-operation/admin/shuttle-stops',
     silentParse(AdminCreateShuttleStopRequestSchema, data),
-  );
-};
-
-// ----- DELETE -----
-
-export const deleteShuttleStop = async (
-  data: AdminDeleteShuttleStopRequest,
-) => {
-  await authInstance.delete(
-    `/v1/shuttle-operation/admin/shuttle-stops`,
-    silentParse(AdminDeleteShuttleStopRequestSchema, data),
   );
 };
 

--- a/src/services/shuttleStops.service.ts
+++ b/src/services/shuttleStops.service.ts
@@ -4,6 +4,8 @@ import {
   AdminCreateShuttleStopRequest,
   AdminDeleteShuttleStopRequest,
   AdminDeleteShuttleStopRequestSchema,
+  AdminSaveShuttleStopTagRequest,
+  AdminSaveShuttleStopTagRequestSchema,
 } from '@/types/shuttleStop.type';
 import { AdminCreateShuttleStopRequestSchema } from '@/types/shuttleStop.type';
 
@@ -24,5 +26,14 @@ export const deleteShuttleStop = async (
   await authInstance.delete(
     `/v1/shuttle-operation/admin/shuttle-stops`,
     silentParse(AdminDeleteShuttleStopRequestSchema, data),
+  );
+};
+
+// ----- PUT -----
+
+export const putShuttleStop = async (data: AdminSaveShuttleStopTagRequest) => {
+  await authInstance.put(
+    `/v1/shuttle-operation/admin/shuttle-stop-tags`,
+    silentParse(AdminSaveShuttleStopTagRequestSchema, data),
   );
 };

--- a/src/services/shuttleStops.service.ts
+++ b/src/services/shuttleStops.service.ts
@@ -1,20 +1,9 @@
 import { silentParse } from '@/utils/parse.util';
 import { authInstance } from './config';
 import {
-  AdminCreateShuttleStopRequest,
   AdminSaveShuttleStopTagRequest,
   AdminSaveShuttleStopTagRequestSchema,
 } from '@/types/shuttleStop.type';
-import { AdminCreateShuttleStopRequestSchema } from '@/types/shuttleStop.type';
-
-// ----- POST -----
-
-export const postShuttleStop = async (data: AdminCreateShuttleStopRequest) => {
-  await authInstance.post(
-    '/v1/shuttle-operation/admin/shuttle-stops',
-    silentParse(AdminCreateShuttleStopRequestSchema, data),
-  );
-};
 
 // ----- PUT -----
 

--- a/src/services/shuttleStops.service.ts
+++ b/src/services/shuttleStops.service.ts
@@ -1,0 +1,28 @@
+import { silentParse } from '@/utils/parse.util';
+import { authInstance } from './config';
+import {
+  AdminCreateShuttleStopRequest,
+  AdminDeleteShuttleStopRequest,
+  AdminDeleteShuttleStopRequestSchema,
+} from '@/types/shuttleStop.type';
+import { AdminCreateShuttleStopRequestSchema } from '@/types/shuttleStop.type';
+
+// ----- POST -----
+
+export const postShuttleStop = async (data: AdminCreateShuttleStopRequest) => {
+  await authInstance.post(
+    '/v1/shuttle-operation/admin/shuttle-stops',
+    silentParse(AdminCreateShuttleStopRequestSchema, data),
+  );
+};
+
+// ----- DELETE -----
+
+export const deleteShuttleStop = async (
+  data: AdminDeleteShuttleStopRequest,
+) => {
+  await authInstance.delete(
+    `/v1/shuttle-operation/admin/shuttle-stops`,
+    silentParse(AdminDeleteShuttleStopRequestSchema, data),
+  );
+};

--- a/src/types/hub.type.ts
+++ b/src/types/hub.type.ts
@@ -19,6 +19,8 @@ export const RegionHubSchema = z.object({
   address: z.string(),
   latitude: z.number(),
   longitude: z.number(),
+  eventDestination: z.boolean(),
+  shuttleHub: z.boolean(),
 });
 export type RegionHub = z.infer<typeof RegionHubSchema>;
 

--- a/src/types/shuttleStop.type.ts
+++ b/src/types/shuttleStop.type.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const AdminCreateShuttleStopRequestSchema = z.object({
+  regionHubId: z.string(),
+  type: z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB']),
+});
+
+export type AdminCreateShuttleStopRequest = z.infer<
+  typeof AdminCreateShuttleStopRequestSchema
+>;
+
+export const AdminDeleteShuttleStopRequestSchema = z.object({
+  regionHubId: z.string(),
+  type: z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB']),
+});
+
+export type AdminDeleteShuttleStopRequest = z.infer<
+  typeof AdminDeleteShuttleStopRequestSchema
+>;

--- a/src/types/shuttleStop.type.ts
+++ b/src/types/shuttleStop.type.ts
@@ -17,3 +17,12 @@ export const AdminDeleteShuttleStopRequestSchema = z.object({
 export type AdminDeleteShuttleStopRequest = z.infer<
   typeof AdminDeleteShuttleStopRequestSchema
 >;
+
+export const AdminSaveShuttleStopTagRequestSchema = z.object({
+  regionHubId: z.string(),
+  types: z.array(z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB'])),
+});
+
+export type AdminSaveShuttleStopTagRequest = z.infer<
+  typeof AdminSaveShuttleStopTagRequestSchema
+>;

--- a/src/types/shuttleStop.type.ts
+++ b/src/types/shuttleStop.type.ts
@@ -9,15 +9,6 @@ export type AdminCreateShuttleStopRequest = z.infer<
   typeof AdminCreateShuttleStopRequestSchema
 >;
 
-export const AdminDeleteShuttleStopRequestSchema = z.object({
-  regionHubId: z.string(),
-  type: z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB']),
-});
-
-export type AdminDeleteShuttleStopRequest = z.infer<
-  typeof AdminDeleteShuttleStopRequestSchema
->;
-
 export const AdminSaveShuttleStopTagRequestSchema = z.object({
   regionHubId: z.string(),
   types: z.array(z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB'])),

--- a/src/types/shuttleStop.type.ts
+++ b/src/types/shuttleStop.type.ts
@@ -1,14 +1,5 @@
 import { z } from 'zod';
 
-export const AdminCreateShuttleStopRequestSchema = z.object({
-  regionHubId: z.string(),
-  type: z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB']),
-});
-
-export type AdminCreateShuttleStopRequest = z.infer<
-  typeof AdminCreateShuttleStopRequestSchema
->;
-
 export const AdminSaveShuttleStopTagRequestSchema = z.object({
   regionHubId: z.string(),
   types: z.array(z.enum(['EVENT_DESTINATION', 'SHUTTLE_HUB'])),


### PR DESCRIPTION
## 개요
장소에 행사장, 정류장의 태그기능이 추가되었습니다.

## 변경사항

(1) 장소 추가 페이지에서 장소 태그 선택 가능
(2) 장소 수정 페이지에서 장소 태그 선택 가능
(3) 장소 대시보드에서 칼럼 추가 및 필터 선택가능

#### 버그 수정
장소 대시보드에서 필터 초기화 되지 않던 이슈 해결

#### 대기중인 작업사항 (작업완료, 다른 pr 로 올려둘 예정)
행사 추가/수정, 노선 추가/수정 에서 행사장/정류장 태그만 regionHub 목록에 표시
-> 기존에 존재하는 정류장들에 태그 반영 작업이 되어있지 않은데 당장 행사장/노선 생성/수정 작업에 차질이 생길 것을 우려하여 운영팀에서해당 작업이 끝나면 해당 부분을 반영할 예정입니다.


### 고민되는 부분
- 장소 추가/수정을 완료하려면 addHub, putShuttleStop API를 차례로 쏴야합니다. 그런데 피치못할 사정으로 addHub만 성공하고 putShuttleStop 은 정상적으로 요청이 처리되지 않는 경우가 이론적으로 생길 수 있습니다. (브라우저가 꺼진다는 등) 이럴때는 따로 처리할 수 있는 방법이 없습니다. 만약에 생기더라도 장소는 추가/수정 완료되고 태그만 붙지 않는 거라. 위험하진 않긴 합니다...  예전에 우리 함께 이야기했던 백엔드에서 gateway 를 도입해서 원하는 형식에 맞게 엔드포인트를 재조립 하는 방법이 되어야 근본적으로 해결될 것 같긴해요

- interface TagStates 는 장소 추가하기와 수정하기, getTags() 함수에서 쓰이는데요. 처음엔 이를 type 파일로 분리시킬까 생각을 했었는데, 다른 곳에서 interface를 type 파일로 분리한 곳이 없고, 대게 컴포넌트 파일이나, service 파일에서 선언해두고 있더라고요. 
  혹은 const type으로 만들어서 분리시킬까도 생각했었는데, 프로젝트 내에 다른 곳에선 객체를 type으로 만들어 두는 경우를 못봐서 그러지는 않았습니다.
  이대로 두는 것이 좋을까요? 



<img width="745" alt="Screenshot 2025-04-01 at 11 27 00 AM" src="https://github.com/user-attachments/assets/1e355fa7-9280-4395-940b-f00bc37ebcc4" />

<img width="840" alt="Screenshot 2025-03-31 at 5 57 30 PM" src="https://github.com/user-attachments/assets/33f68c7b-637f-4bf9-a08b-4bd4f3993b25" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).