### PR TITLE
feat: 지도에 태그에 따라 핀 구분하기

### DIFF
--- a/public/icons/bus-stop-marker-cyan.svg
+++ b/public/icons/bus-stop-marker-cyan.svg
@@ -1,0 +1,43 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8332_35458)">
+<g filter="url(#filter0_d_8332_35458)">
+<path d="M6.02858 13.4693C2.6468 8.63815 6.10299 2 12.0001 2C17.8972 2 21.3534 8.63814 17.9716 13.4692L12.0001 22L6.02858 13.4693Z" fill="#DEFF4E"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.3018 9.3674C19.2913 10.7562 18.876 12.1774 17.9716 13.4692L12.0001 22L12 21.9999V2C12 2 12.0001 2 12.0001 2C16.2795 2 19.2734 5.49563 19.3018 9.25968V9.3674Z" fill="#CBF419"/>
+<circle cx="12" cy="9.30713" r="5.79883" fill="white"/>
+<mask id="mask0_8332_35458" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="7" y="4" width="10" height="10">
+<rect x="7.5293" y="4.83691" width="8.94092" height="8.94092" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_8332_35458)">
+<path d="M9.9583 12.4738C9.87914 12.4738 9.8128 12.447 9.75927 12.3934C9.70569 12.3399 9.6789 12.2735 9.6789 12.1944V11.4593C9.56236 11.371 9.45441 11.246 9.35507 11.0843C9.25573 10.9226 9.20605 10.741 9.20605 10.5394V7.07195C9.20605 6.62105 9.43017 6.29102 9.87839 6.08184C10.3266 5.87266 11.0338 5.76807 12 5.76807C13.0011 5.76807 13.7171 5.86859 14.1479 6.06964C14.5787 6.27062 14.7941 6.60473 14.7941 7.07195V10.5394C14.7941 10.741 14.7445 10.9226 14.6451 11.0843C14.5458 11.246 14.4378 11.371 14.3213 11.4593V12.1944C14.3213 12.2735 14.2945 12.3399 14.2409 12.3934C14.1874 12.447 14.121 12.4738 14.0419 12.4738H13.8126C13.7335 12.4738 13.6671 12.447 13.6136 12.3934C13.56 12.3399 13.5333 12.2735 13.5333 12.1944V11.7287H10.4669V12.1944C10.4669 12.2735 10.4401 12.3399 10.3866 12.3934C10.333 12.447 10.2667 12.4738 10.1876 12.4738H9.9583ZM9.76486 8.74837H14.2353V7.35853H9.76486V8.74837ZM10.697 10.7257C10.8326 10.7257 10.9475 10.6782 11.0418 10.5833C11.1362 10.4884 11.1834 10.3732 11.1834 10.2377C11.1834 10.1021 11.1359 9.98722 11.041 9.8929C10.9461 9.79853 10.8309 9.75134 10.6954 9.75134C10.5598 9.75134 10.4449 9.79881 10.3506 9.89374C10.2562 9.98861 10.209 10.1038 10.209 10.2394C10.209 10.3749 10.2565 10.4898 10.3514 10.5841C10.4463 10.6785 10.5615 10.7257 10.697 10.7257ZM13.3048 10.7257C13.4404 10.7257 13.5553 10.6782 13.6496 10.5833C13.744 10.4884 13.7912 10.3732 13.7912 10.2377C13.7912 10.1021 13.7437 9.98722 13.6488 9.8929C13.5539 9.79853 13.4387 9.75134 13.3031 9.75134C13.1676 9.75134 13.0527 9.79881 12.9584 9.89374C12.864 9.98861 12.8168 10.1038 12.8168 10.2394C12.8168 10.3749 12.8643 10.4898 12.9592 10.5841C13.0541 10.6785 13.1693 10.7257 13.3048 10.7257Z" fill="#CBF419"/>
+</g>
+<g filter="url(#filter1_d_8332_35458)">
+<path d="M6.10952 13.4119C2.77415 8.64708 6.18291 2.1 11.9991 2.1C17.8153 2.1 21.2241 8.64707 17.8887 13.4119L11.9991 21.8256L6.10952 13.4119Z" stroke="#C3E729" stroke-width="0.2" shape-rendering="crispEdges"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_8332_35458" x="3.69824" y="1" width="18.6035" height="24" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35458"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35458" result="shape"/>
+</filter>
+<filter id="filter1_d_8332_35458" x="3.69727" y="1" width="18.6035" height="24" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35458"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35458" result="shape"/>
+</filter>
+<clipPath id="clip0_8332_35458">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/bus-stop-marker.svg
+++ b/public/icons/bus-stop-marker.svg
@@ -1,0 +1,43 @@
+<svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8332_35753)">
+<g filter="url(#filter0_d_8332_35753)">
+<path d="M8.03843 18.4588C3.5294 12.0174 8.13764 3.1665 16.0005 3.1665C23.8633 3.1665 28.4715 12.0174 23.9625 18.4588L16.0005 29.8332L8.03843 18.4588Z" fill="#235B9C"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.0002 29.833H16V3.1665C16 3.1665 16.0001 3.1665 16.0001 3.1665C21.706 3.1665 25.698 7.82739 25.7357 12.8462V12.9896C25.7218 14.8414 25.168 16.7363 23.9622 18.4588L16.0002 29.833Z" fill="#0B3A70"/>
+<circle cx="16.0003" cy="12.9095" r="7.73177" fill="white"/>
+<mask id="mask0_8332_35753" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="6" width="12" height="13">
+<rect x="10.0391" y="6.94922" width="11.9212" height="11.9212" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_8332_35753)">
+<path d="M13.2774 17.1318C13.1719 17.1318 13.0834 17.0961 13.012 17.0247C12.9406 16.9533 12.9049 16.8649 12.9049 16.7593V15.7793C12.7495 15.6615 12.6056 15.4948 12.4731 15.2792C12.3406 15.0636 12.2744 14.8215 12.2744 14.5528V9.92943C12.2744 9.32824 12.5732 8.88819 13.1709 8.60928C13.7684 8.33037 14.7114 8.19092 15.9997 8.19092C17.3345 8.19092 18.2891 8.32495 18.8635 8.59301C19.438 8.86099 19.7252 9.30646 19.7252 9.92943V14.5528C19.7252 14.8215 19.659 15.0636 19.5265 15.2792C19.394 15.4948 19.2501 15.6615 19.0947 15.7793V16.7593C19.0947 16.8649 19.059 16.9533 18.9876 17.0247C18.9162 17.0961 18.8277 17.1318 18.7222 17.1318H18.4165C18.311 17.1318 18.2225 17.0961 18.1511 17.0247C18.0797 16.9533 18.044 16.8649 18.044 16.7593V16.1384H13.9556V16.7593C13.9556 16.8649 13.9199 16.9533 13.8485 17.0247C13.7771 17.0961 13.6886 17.1318 13.5831 17.1318H13.2774ZM13.0195 12.1647H18.9801V10.3115H13.0195V12.1647ZM14.2624 14.8011C14.4431 14.8011 14.5964 14.7378 14.7221 14.6112C14.8479 14.4847 14.9109 14.3311 14.9109 14.1504C14.9109 13.9697 14.8476 13.8165 14.721 13.6907C14.5945 13.5649 14.4409 13.5019 14.2602 13.5019C14.0794 13.5019 13.9262 13.5652 13.8005 13.6918C13.6746 13.8183 13.6117 13.9719 13.6117 14.1526C13.6117 14.3334 13.675 14.4866 13.8016 14.6124C13.9281 14.7382 14.0817 14.8011 14.2624 14.8011ZM17.7394 14.8011C17.9201 14.8011 18.0734 14.7378 18.1991 14.6112C18.325 14.4847 18.3879 14.3311 18.3879 14.1504C18.3879 13.9697 18.3246 13.8165 18.198 13.6907C18.0715 13.5649 17.9179 13.5019 17.7372 13.5019C17.5565 13.5019 17.4032 13.5652 17.2775 13.6918C17.1516 13.8183 17.0887 13.9719 17.0887 14.1526C17.0887 14.3334 17.152 14.4866 17.2786 14.6124C17.4051 14.7382 17.5587 14.8011 17.7394 14.8011Z" fill="#0B3A70"/>
+</g>
+<g filter="url(#filter1_d_8332_35753)">
+<path d="M8.14668 18.3824C3.69951 12.0293 8.24453 3.29984 15.9995 3.29984C23.7544 3.29984 28.2995 12.0293 23.8523 18.3824L15.9995 29.6007L8.14668 18.3824Z" stroke="#082F5A" stroke-width="0.266667" shape-rendering="crispEdges"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_8332_35753" x="4.93132" y="1.83317" width="24.805" height="31.9998" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33333" dy="1.33333"/>
+<feGaussianBlur stdDeviation="1.33333"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35753"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35753" result="shape"/>
+</filter>
+<filter id="filter1_d_8332_35753" x="4.93034" y="1.83317" width="24.805" height="31.9998" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33333" dy="1.33333"/>
+<feGaussianBlur stdDeviation="1.33333"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35753"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35753" result="shape"/>
+</filter>
+<clipPath id="clip0_8332_35753">
+<rect width="32" height="32" fill="white" transform="translate(0 0.5)"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/default-marker.svg
+++ b/public/icons/default-marker.svg
@@ -1,0 +1,43 @@
+<svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8332_35776)">
+<g filter="url(#filter0_d_8332_35776)">
+<path d="M8.03843 18.4588C3.5294 12.0174 8.13764 3.1665 16.0005 3.1665C23.8633 3.1665 28.4715 12.0174 23.9625 18.4588L16.0005 29.8332L8.03843 18.4588Z" fill="#DEDEDE"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.0002 29.833H16V3.1665C16 3.1665 16.0001 3.1665 16.0001 3.1665C21.706 3.1665 25.698 7.82739 25.7357 12.8462V12.9896C25.7218 14.8414 25.168 16.7363 23.9622 18.4588L16.0002 29.833Z" fill="#CFCFCF"/>
+<circle cx="16.0003" cy="12.9095" r="7.73177" fill="#F8F8F8"/>
+<mask id="mask0_8332_35776" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="7" width="12" height="12">
+<rect x="10.4004" y="7.55078" width="11" height="11" fill="#007459"/>
+</mask>
+<g mask="url(#mask0_8332_35776)">
+<path d="M12.3562 13.9722C12.1028 13.9722 11.8858 13.8819 11.7054 13.7014C11.5248 13.5209 11.4346 13.304 11.4346 13.0505C11.4346 12.7971 11.5248 12.5801 11.7054 12.3997C11.8858 12.2192 12.1028 12.1289 12.3562 12.1289C12.6096 12.1289 12.8266 12.2192 13.0072 12.3997C13.1876 12.5801 13.2778 12.7971 13.2778 13.0505C13.2778 13.304 13.1876 13.5209 13.0072 13.7014C12.8266 13.8819 12.6096 13.9722 12.3562 13.9722ZM15.9009 13.9722C15.6475 13.9722 15.4306 13.8819 15.2501 13.7014C15.0696 13.5209 14.9793 13.304 14.9793 13.0505C14.9793 12.7971 15.0696 12.5801 15.2501 12.3997C15.4306 12.2192 15.6475 12.1289 15.9009 12.1289C16.1544 12.1289 16.3713 12.2192 16.5518 12.3997C16.7323 12.5801 16.8226 12.7971 16.8226 13.0505C16.8226 13.304 16.7323 13.5209 16.5518 13.7014C16.3713 13.8819 16.1544 13.9722 15.9009 13.9722ZM19.4457 13.9722C19.1922 13.9722 18.9753 13.8819 18.7947 13.7014C18.6143 13.5209 18.5241 13.304 18.5241 13.0505C18.5241 12.7971 18.6143 12.5801 18.7947 12.3997C18.9753 12.2192 19.1922 12.1289 19.4457 12.1289C19.6991 12.1289 19.9161 12.2192 20.0965 12.3997C20.2771 12.5801 20.3673 12.7971 20.3673 13.0505C20.3673 13.304 20.2771 13.5209 20.0965 13.7014C19.9161 13.8819 19.6991 13.9722 19.4457 13.9722Z" fill="#CFCFCF"/>
+</g>
+<g filter="url(#filter1_d_8332_35776)">
+<path d="M8.14571 18.3824C3.69853 12.0293 8.24356 3.29984 15.9985 3.29984C23.7535 3.29984 28.2985 12.0293 23.8513 18.3824L15.9985 29.6007L8.14571 18.3824Z" stroke="#D2D2D2" stroke-width="0.266667" shape-rendering="crispEdges"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_8332_35776" x="4.93132" y="1.83317" width="24.805" height="31.9998" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33333" dy="1.33333"/>
+<feGaussianBlur stdDeviation="1.33333"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35776"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35776" result="shape"/>
+</filter>
+<filter id="filter1_d_8332_35776" x="4.92936" y="1.83317" width="24.805" height="31.9998" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33333" dy="1.33333"/>
+<feGaussianBlur stdDeviation="1.33333"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35776"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35776" result="shape"/>
+</filter>
+<clipPath id="clip0_8332_35776">
+<rect width="32" height="32" fill="white" transform="translate(0 0.5)"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/event-venue-marker.svg
+++ b/public/icons/event-venue-marker.svg
@@ -1,0 +1,43 @@
+<svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_8332_35764)">
+<g filter="url(#filter0_d_8332_35764)">
+<path d="M8.03843 18.4588C3.5294 12.0174 8.13764 3.1665 16.0005 3.1665C23.8633 3.1665 28.4715 12.0174 23.9625 18.4588L16.0005 29.8332L8.03843 18.4588Z" fill="#029D79"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.0002 29.833H16V3.1665C16 3.1665 16.0001 3.1665 16.0001 3.1665C21.706 3.1665 25.698 7.82739 25.7357 12.8462V12.9896C25.7218 14.8414 25.168 16.7363 23.9622 18.4588L16.0002 29.833Z" fill="#007459"/>
+<circle cx="16.0003" cy="12.9095" r="7.73177" fill="white"/>
+<mask id="mask0_8332_35764" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="7" width="12" height="12">
+<rect x="10.4316" y="7.34277" width="11.1341" height="11.1341" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_8332_35764)">
+<path d="M12.1622 10.5898V8.87693L13.8751 9.73333L12.1622 10.5898ZM18.5858 10.5898V8.87693L20.2987 9.73333L18.5858 10.5898ZM15.5882 10.1616V8.44873L17.3011 9.30513L15.5882 10.1616ZM14.7227 17.3435C14.2999 17.3078 13.8981 17.2535 13.5174 17.1807C13.1368 17.1078 12.8019 17.0191 12.5128 16.9144C12.2238 16.8097 11.9935 16.6898 11.8219 16.5548C11.6503 16.4198 11.5645 16.2723 11.5645 16.1122V12.1154C11.5645 11.937 11.6781 11.7713 11.9053 11.6185C12.1325 11.4656 12.4444 11.3313 12.8412 11.2157C13.2379 11.1 13.7066 11.0084 14.2472 10.9409C14.7878 10.8734 15.3716 10.8397 15.9985 10.8397C16.6254 10.8397 17.2092 10.8734 17.7498 10.9409C18.2904 11.0084 18.7591 11.1 19.1558 11.2157C19.5526 11.3313 19.8645 11.4656 20.0917 11.6185C20.3189 11.7713 20.4325 11.937 20.4325 12.1154V16.1122C20.4325 16.2723 20.3467 16.4198 20.1751 16.5548C20.0035 16.6898 19.7732 16.8097 19.4842 16.9144C19.1951 17.0191 18.8602 17.1078 18.4795 17.1807C18.0989 17.2535 17.6971 17.3078 17.2743 17.3435V15.1844H14.7227V17.3435ZM15.9985 12.6954C16.7574 12.6954 17.4406 12.6427 18.0482 12.5374C18.6558 12.4322 19.1234 12.3007 19.4511 12.1431C19.4006 12.042 19.0688 11.9155 18.456 11.7634C17.8431 11.6115 17.0239 11.5355 15.9985 11.5355C14.9731 11.5355 14.1539 11.6115 13.541 11.7634C12.9282 11.9155 12.5964 12.042 12.5459 12.1431C12.8736 12.3007 13.3241 12.4322 13.8975 12.5374C14.4708 12.6427 15.1712 12.6954 15.9985 12.6954Z" fill="#007459"/>
+</g>
+<g filter="url(#filter1_d_8332_35764)">
+<path d="M8.14571 18.3824C3.69853 12.0293 8.24356 3.29984 15.9985 3.29984C23.7535 3.29984 28.2985 12.0293 23.8513 18.3824L15.9985 29.6007L8.14571 18.3824Z" stroke="#00674F" stroke-width="0.266667" shape-rendering="crispEdges"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_8332_35764" x="4.93132" y="1.83317" width="24.805" height="31.9998" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33333" dy="1.33333"/>
+<feGaussianBlur stdDeviation="1.33333"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35764"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35764" result="shape"/>
+</filter>
+<filter id="filter1_d_8332_35764" x="4.92936" y="1.83317" width="24.805" height="31.9998" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33333" dy="1.33333"/>
+<feGaussianBlur stdDeviation="1.33333"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_8332_35764"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_8332_35764" result="shape"/>
+</filter>
+<clipPath id="clip0_8332_35764">
+<rect width="32" height="32" fill="white" transform="translate(0 0.5)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/locations/map/components/hubsMap.tsx
+++ b/src/app/locations/map/components/hubsMap.tsx
@@ -13,6 +13,8 @@ interface HubData {
   latitude: number;
   longitude: number;
   regionId: string;
+  shuttleHub: boolean;
+  eventDestination: boolean;
 }
 
 interface Coord {
@@ -25,8 +27,11 @@ const MAP_CONSTANTS = {
   INITIAL_ZOOM_LEVEL: 4,
   DEFAULT_LAT: 37.574187,
   DEFAULT_LNG: 126.976882,
-  HUB_MARKER_IMAGE_URL:
-    'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
+  MARKER_IMAGES: {
+    DEFAULT: '/icons/default-marker.svg',
+    BUS_STOP: '/icons/bus-stop-marker.svg',
+    EVENT_VENUE: '/icons/event-venue-marker.svg',
+  },
 };
 
 const HubsMap = () => {
@@ -57,16 +62,31 @@ const HubsMap = () => {
           latitude: regionHub.latitude,
           longitude: regionHub.longitude,
           regionId: regionHub.regionId,
+          shuttleHub: regionHub.shuttleHub,
+          eventDestination: regionHub.eventDestination,
         })),
     [regionHubs],
   );
 
-  const createHubsMarkerImage = useCallback(() => {
-    const imageSrc = MAP_CONSTANTS.HUB_MARKER_IMAGE_URL;
-    return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(24, 35), {
-      offset: new kakao.maps.Point(12, 35),
-    });
-  }, []);
+  const createHubsMarkerImage = useCallback(
+    ({
+      shuttleHub,
+      eventDestination,
+    }: {
+      shuttleHub: boolean;
+      eventDestination: boolean;
+    }) => {
+      const imageSrc = shuttleHub
+        ? MAP_CONSTANTS.MARKER_IMAGES.BUS_STOP
+        : eventDestination
+          ? MAP_CONSTANTS.MARKER_IMAGES.EVENT_VENUE
+          : MAP_CONSTANTS.MARKER_IMAGES.DEFAULT;
+      return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(40, 40), {
+        offset: new kakao.maps.Point(20, 40),
+      });
+    },
+    [],
+  );
 
   const setCoordWithAddress = useCallback(
     async (latLng: kakao.maps.LatLng) => {
@@ -122,7 +142,10 @@ const HubsMap = () => {
         map: map,
         position: position,
         title: hub.name,
-        image: createHubsMarkerImage(),
+        image: createHubsMarkerImage({
+          shuttleHub: hub.shuttleHub,
+          eventDestination: hub.eventDestination,
+        }),
       });
 
       const customOverlay = new kakao.maps.CustomOverlay({

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -8,6 +8,17 @@ import { useGetRegionHubsWithoutPagination } from '@/services/hub.service';
 import { findRegionId, toAddress } from '@/utils/region.util';
 import { standardizeRegionName } from '@/utils/region.util';
 
+const MAP_CONSTANTS = {
+  INITIAL_ZOOM_LEVEL: 4,
+  DEFAULT_LAT: 37.574187,
+  DEFAULT_LNG: 126.976882,
+  MARKER_IMAGES: {
+    DEFAULT: '/icons/default-marker.svg',
+    BUS_STOP: '/icons/bus-stop-marker.svg',
+    EVENT_VENUE: '/icons/event-venue-marker.svg',
+  },
+};
+
 interface Props {
   coord: Coord;
   setCoord: (coord: Coord) => void;
@@ -18,6 +29,8 @@ interface HubData {
   name: string;
   latitude: number;
   longitude: number;
+  shuttleHub: boolean;
+  eventDestination: boolean;
 }
 
 const INITIAL_ZOOM_LEVEL = 4;
@@ -49,6 +62,8 @@ const CoordInput = ({ coord, setCoord }: Props) => {
         name: regionHub.name,
         latitude: regionHub.latitude,
         longitude: regionHub.longitude,
+        shuttleHub: regionHub.shuttleHub,
+        eventDestination: regionHub.eventDestination,
       })),
     [regionHubs],
   );
@@ -100,13 +115,25 @@ const CoordInput = ({ coord, setCoord }: Props) => {
     }
   };
 
-  const createHubsMarkerImage = () => {
-    const imageSrc =
-      'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
-    return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(24, 35), {
-      offset: new kakao.maps.Point(12, 35),
-    });
-  };
+  const createHubsMarkerImage = useCallback(
+    ({
+      shuttleHub,
+      eventDestination,
+    }: {
+      shuttleHub: boolean;
+      eventDestination: boolean;
+    }) => {
+      const imageSrc = shuttleHub
+        ? MAP_CONSTANTS.MARKER_IMAGES.BUS_STOP
+        : eventDestination
+          ? MAP_CONSTANTS.MARKER_IMAGES.EVENT_VENUE
+          : MAP_CONSTANTS.MARKER_IMAGES.DEFAULT;
+      return new kakao.maps.MarkerImage(imageSrc, new kakao.maps.Size(40, 40), {
+        offset: new kakao.maps.Point(20, 40),
+      });
+    },
+    [],
+  );
 
   // 여러 마커 표시 함수
   const displayHubs = (hubList: HubData[]) => {
@@ -118,7 +145,10 @@ const CoordInput = ({ coord, setCoord }: Props) => {
         map: kakaoMapRef.current ?? undefined,
         position: position,
         title: hub.name,
-        image: createHubsMarkerImage(),
+        image: createHubsMarkerImage({
+          shuttleHub: hub.shuttleHub,
+          eventDestination: hub.eventDestination,
+        }),
       });
 
       const customOverlay = new kakao.maps.CustomOverlay({


### PR DESCRIPTION
## 개요
장소 태그 반영 두번째 작업입니다.

## 변경사항
- 장소 필터 삭제 (기획 변경으로 이후 pr 에서 태그에 따라 필터링하는 걸 반영하겠습니다.)
- 장소 - 지도 보기, 장소 추가/수정 페이지에서 정류장들이 부여된 태그에 따라 다르게 보여집니다. 
  - 회색핀(미설정), 남색핀(버스정류장), 초록핀(행사장소)
  - 많은 핀들이 지도에 보일 수록 성능이 느려져 이후 최적화 작업을 진행할 예정입니다. (일정 줌레벨 이상에서는 갯수만 보여주거나... 혹은 성능이 느려지는 원인을 찾아서 해결할 수 있거나..)


| 스크린샷 |
|--------|
| ![Screenshot 2025-04-01 at 4 04 06 PM](https://github.com/user-attachments/assets/301f2c61-2fc2-4039-bc56-5f477704f95a)  |
| ![Screenshot 2025-04-01 at 4 04 12 PM](https://github.com/user-attachments/assets/4dba92a9-7b95-4fee-af7a-e871638a7ac7)  | 

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).