### PR TITLE
fix: 특정 지역의 정류장 정보 가져와지지 않는 에러 해결

### DIFF
--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -159,7 +159,7 @@ const CoordInput = ({ coord, setCoord }: Props) => {
     try {
       const address = await toAddress(center.getLat(), center.getLng());
       const bigRegion = standardizeRegionName(address.region_1depth_name);
-      const smallRegion = address.region_2depth_name;
+      const smallRegion = address.region_2depth_name.split(' ')[0];
       const region = `${bigRegion} ${smallRegion}`;
       const regionId = findRegionId(bigRegion, smallRegion);
       setCurrentRegion(region);


### PR DESCRIPTION
## 개요
간혹 경기도 고양시 덕양구 처럼 region_2depth_name에서 고양시 덕양구와 같은 형식으로 api response 가 오는 경우 지역 정류장 정보를 갖고오지 못하는 이슈가 발견 되어 이를 해결하였습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).