### PR TITLE
fix: 이벤트 수정페이지에서 date 가 korean Time이 아니어서 수정완료가 안되던 이슈 해결

### DIFF
--- a/src/app/events/[eventId]/edit/page.tsx
+++ b/src/app/events/[eventId]/edit/page.tsx
@@ -56,7 +56,7 @@ const EditEventForm = ({ event }: EditEventFormProps) => {
     dailyEvents: event?.dailyEvents?.map((dailyEvent) => ({
       status: dailyEvent.status,
       dailyEventId: dailyEvent.dailyEventId,
-      date: dayjs(dailyEvent.date, 'Asia/Seoul').format('YYYY-MM-DD'),
+      date: dayjs(dailyEvent.date, 'Asia/Seoul').toISOString(),
     })),
     artistIds:
       event?.eventArtists?.map((artist) => ({
@@ -67,7 +67,7 @@ const EditEventForm = ({ event }: EditEventFormProps) => {
   const previousDailyEvents = event?.dailyEvents?.map((dailyEvent) => ({
     status: dailyEvent.status,
     dailyEventId: dailyEvent.dailyEventId,
-    date: dayjs(dailyEvent.date, 'Asia/Seoul').format('YYYY-MM-DD'),
+    date: dayjs(dailyEvent.date, 'Asia/Seoul').toISOString(),
   }));
 
   const { control, handleSubmit } = useForm<EditEventFormData>({


### PR DESCRIPTION
## 개요
이벤트 수정페이지에서 date 가 korean Time이 아니어서 수정완료가 안되던 이슈를 해결하였습니다.

## 변경사항
- 해당 이벤트의 time 들이 ISOString으로 관리되고 있지 않고, format(yyyy-mm-dd)로 되어있던 부분을 변경했습니다.
이 때문에 새로 추가한 date는 utc 로 관리되고있는데, 기존의 행사 date들이 yyyy-mm-dd 형식으로 관리되고있어. API 요청이 실패하는 이슈를 해결했습니다.

![image](https://github.com/user-attachments/assets/72e825ec-1401-4d26-8ee5-5194a2124e5e)

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).