### PR TITLE
fix: 행사탭의 행사 날짜들 정렬 적용

### DIFF
--- a/src/app/events/table.type.tsx
+++ b/src/app/events/table.type.tsx
@@ -47,7 +47,12 @@ export const columns = [
     },
   }),
   columnHelper.accessor(
-    (row) => row.dailyEvents.map((dailyEvent) => dailyEvent.date),
+    (row) =>
+      row.dailyEvents
+        .toSorted(
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+        )
+        .map((dailyEvent) => dailyEvent.date),
     {
       header: '날짜',
       cell: ({ getValue }) => {

--- a/src/app/events/table.type.tsx
+++ b/src/app/events/table.type.tsx
@@ -7,6 +7,7 @@ import { EventWithStatisticsViewEntity } from '@/types/event.type';
 import { DEFAULT_EVENT_IMAGE } from '@/constants/common';
 import Stringifier from '@/utils/stringifier.util';
 import BlueLink from '@/components/link/BlueLink';
+import dayjs from 'dayjs';
 
 const columnHelper = createColumnHelper<EventWithStatisticsViewEntity>();
 
@@ -49,9 +50,7 @@ export const columns = [
   columnHelper.accessor(
     (row) =>
       row.dailyEvents
-        .toSorted(
-          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-        )
+        .toSorted((a, b) => dayjs(a.date).diff(dayjs(b.date)))
         .map((dailyEvent) => dailyEvent.date),
     {
       header: '날짜',


### PR DESCRIPTION
## 개요
행사탭의 행사 날짜에 정렬을 적용하였습니다.

이전에는 아래의 이미지처럼 시간이 뒤죽박죽으로 보이는 이슈가 있습니다.
<img width="824" alt="Screenshot 2025-04-22 at 10 21 07 AM" src="https://github.com/user-attachments/assets/08b73ac6-f6f9-46cc-8a4d-02f5a1765336" />

## 변경사항
#### 이전
<img width="616" alt="Screenshot 2025-04-22 at 11 17 06 AM" src="https://github.com/user-attachments/assets/3be8aa6d-c76b-4eef-97f4-5389dd69d57a" />

#### 이후
<img width="734" alt="Screenshot 2025-04-22 at 11 15 14 AM" src="https://github.com/user-attachments/assets/2f1440a9-a834-4a2c-9200-85dfed723b05" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).