### PR TITLE
fix: 행사 dailyEvents 정렬 이슈 해결

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -10,6 +10,7 @@ import { useMemo } from 'react';
 import EventFilter from './components/EventFilter';
 import useEventFilter from './hooks/useEventFilter';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import dayjs from 'dayjs';
 
 const EVENT_PAGINATION_LIMIT = 7;
 
@@ -26,7 +27,17 @@ const Page = () => {
   });
 
   const flattenedEventsStats = useMemo(
-    () => eventsStats?.pages.flatMap((page) => page.events),
+    () =>
+      eventsStats?.pages
+        .flatMap((page) => page.events)
+        .map((event) => ({
+          ...event,
+          dailyEvents: event.dailyEvents
+            ? [...event.dailyEvents].sort((a, b) =>
+                dayjs(a.date).diff(dayjs(b.date)),
+              )
+            : [],
+        })),
     [eventsStats],
   );
 

--- a/src/app/events/table.type.tsx
+++ b/src/app/events/table.type.tsx
@@ -7,7 +7,6 @@ import { EventWithStatisticsViewEntity } from '@/types/event.type';
 import { DEFAULT_EVENT_IMAGE } from '@/constants/common';
 import Stringifier from '@/utils/stringifier.util';
 import BlueLink from '@/components/link/BlueLink';
-import dayjs from 'dayjs';
 
 const columnHelper = createColumnHelper<EventWithStatisticsViewEntity>();
 
@@ -48,10 +47,7 @@ export const columns = [
     },
   }),
   columnHelper.accessor(
-    (row) =>
-      row.dailyEvents
-        .toSorted((a, b) => dayjs(a.date).diff(dayjs(b.date)))
-        .map((dailyEvent) => dailyEvent.date),
+    (row) => row.dailyEvents.map((dailyEvent) => dailyEvent.date),
     {
       header: '날짜',
       cell: ({ getValue }) => {


### PR DESCRIPTION
## 개요
이전 #199 작업 이후 버그를 발견했습니다.
행사 목록에서 dailyEvents 들은 올바른 순서대로 표기되는데 막상 상세 정보를 눌러서 나오는 페이지들은 다른 dailyEvents 에 속하는 페이지였습니다. 
-> `table.type.tsx` 에서 정렬을 수행하지 않고, `app/events/page.tsx` 에서 `dailyEvents`정렬을 진행합니다.



## 변경사항
| 수정 전 | 수정 후 |
|--------|--------|
 | <img width="742" alt="Screenshot 2025-05-13 at 1 30 14 PM" src="https://github.com/user-attachments/assets/1a20def8-27e2-4286-9628-13997f7e9eb8" /> | <img width="738" alt="Screenshot 2025-05-13 at 1 29 16 PM" src="https://github.com/user-attachments/assets/ae1aa073-0e55-45e0-90c0-1d6d9c173688" /> |

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).