### PR TITLE
feat: 일자별 행사의 수요조사 종료 시간 반영

### DIFF
--- a/src/app/events/[eventId]/edit/form.type.ts
+++ b/src/app/events/[eventId]/edit/form.type.ts
@@ -4,6 +4,7 @@ import {
   EventTypeEnum,
   UpdateEventRequest,
 } from '@/types/event.type';
+import dayjs from 'dayjs';
 
 export const EditEventFormSchema = z.object({
   status: EventStatusEnum,
@@ -31,5 +32,9 @@ export const conform = (data: EditEventFormData): UpdateEventRequest => {
   return {
     ...data,
     artistIds: artistIds.map((artist) => artist.artistId),
+    dailyEvents: data.dailyEvents.map((dailyEvent) => ({
+      ...dailyEvent,
+      closeDeadline: dayjs(dailyEvent.date).subtract(14, 'day').toISOString(),
+    })),
   } satisfies UpdateEventRequest;
 };

--- a/src/app/events/new/form.type.ts
+++ b/src/app/events/new/form.type.ts
@@ -1,4 +1,5 @@
 import { CreateEventRequest } from '@/types/event.type';
+import dayjs from 'dayjs';
 import { z } from 'zod';
 
 export const CreateEventFormSchema = z.object({
@@ -18,8 +19,14 @@ export const conform = (data: CreateEventFormData): CreateEventRequest => {
   const artistIds = data.artistIds.filter(
     (artist): artist is { artistId: string } => artist.artistId !== null,
   );
+  // TODO: 추후 일자별 행사 수요조사 종료 시간을 폼에 추가해야 함
+  const dailyEvents = data.dailyEvents.map((dailyEvent) => ({
+    ...dailyEvent,
+    closeDeadline: dayjs(dailyEvent.date).subtract(14, 'day').toISOString(),
+  }));
   return {
     ...data,
     artistIds: artistIds.map((artist) => artist.artistId),
+    dailyEvents,
   } satisfies CreateEventRequest;
 };

--- a/src/types/event.type.ts
+++ b/src/types/event.type.ts
@@ -21,6 +21,7 @@ export const EventDailyShuttlesInEventsViewEntitySchema = z
     dailyEventId: z.string(),
     date: z.string(),
     status: EventStatusEnum,
+    closeDeadline: z.string(),
   })
   .strict();
 export type EventDailyShuttlesInEventsViewEntity = z.infer<
@@ -78,7 +79,9 @@ export const CreateEventRequestSchema = z.object({
   imageUrl: z.string().url(),
   regionId: z.string(),
   regionHubId: z.string(),
-  dailyEvents: z.object({ date: z.string() }).array(),
+  dailyEvents: z
+    .object({ date: z.string(), closeDeadline: z.string() })
+    .array(),
   type: EventTypeEnum,
   artistIds: z.string().array(),
 });
@@ -96,6 +99,7 @@ export const UpdateEventRequestSchema = z
         status: EventStatusEnum.optional(),
         dailyEventId: z.string().optional(),
         date: z.string(),
+        closeDeadline: z.string(),
       })
       .array(),
     type: EventTypeEnum,


### PR DESCRIPTION
## 개요

일자별 행사의 수요조사 종료 시간을 반영했습니다.
현재 14일 전으로 자동으로 들어가도록 처리했고, 추후 폼 내부에서 개별적으로 설정 가능하도록 수정할 예정입니다.


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).