### PR TITLE
fix: 쿠폰 날짜 선택시 UTC로 반영 안되던 이슈 해결

### DIFF
--- a/src/app/coupons/new/page.tsx
+++ b/src/app/coupons/new/page.tsx
@@ -9,6 +9,7 @@ import { CreateCouponRequest } from '@/types/coupon.type';
 import { Label, Radio } from '@headlessui/react';
 import { Field } from '@headlessui/react';
 import { RadioGroup } from '@headlessui/react';
+import dayjs from 'dayjs';
 import { CheckIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Controller, useForm } from 'react-hook-form';
@@ -46,7 +47,11 @@ const Page = () => {
 
   const router = useRouter();
   const onSubmit = async (data: CreateCouponRequest) => {
-    postCoupon(data);
+    postCoupon({
+      ...data,
+      validFrom: dayjs(data.validFrom).toISOString(),
+      validTo: dayjs(data.validTo).toISOString(),
+    });
   };
 
   return (


### PR DESCRIPTION
## 개요
쿠폰 생성시 UTC 날짜기준으로 post 하지 않던 이슈를 해결하였습니다.

상단 쿠폰이 버그픽스후 생성된 쿠폰입니다. 제대로된 날짜와 시간 값이 반영되어있습니다.
목록에서는 자세한 시간까지 표기되던데 이후 시간을 표현해줄 필요가 있는지 논의해보면 좋을 것 같네요 
필요하다면, 쿠폰 생성시 상세 시각까지 지정하도록 바뀌어야할 거 같아요

<img width="808" alt="Screenshot 2025-05-21 at 6 37 19 PM" src="https://github.com/user-attachments/assets/766bd052-0be8-44c3-a764-039470b7b183" />

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).