### PR TITLE
feat: 노선 상태 변경 기능 추가

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/EditRouteStatusDialog.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/EditRouteStatusDialog.tsx
@@ -67,6 +67,7 @@ const EditRouteStatusDialog = ({ shuttleRoute }: Props) => {
     onSuccess: () => {
       alert('노선 상태가 수정되었습니다.');
       setIsOpen(false);
+      window.location.reload();
     },
     onError: (error) => {
       alert(`노선 상태 수정에 실패했습니다.\n${error}`);

--- a/src/app/events/[eventId]/dates/[dailyEventId]/EditRouteStatusDialog.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/EditRouteStatusDialog.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import {
+  Description,
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/react';
+import { useMemo, useState } from 'react';
+import BlueButton from '@/components/link/BlueButton';
+import {
+  ArrowDownIcon,
+  ChevronDownIcon,
+  MessageSquareWarningIcon,
+} from 'lucide-react';
+import { Controller, useForm, useWatch } from 'react-hook-form';
+import Stringifier from '@/utils/stringifier.util';
+import {
+  AdminShuttleRoutesViewEntity,
+  ShuttleRouteStatus,
+  ShuttleRouteStatusEnum,
+} from '@/types/shuttleRoute.type';
+import { usePutShuttleRoute } from '@/services/shuttleRoute.service';
+
+interface Props {
+  shuttleRoute: AdminShuttleRoutesViewEntity;
+}
+
+const EditRouteStatusDialog = ({ shuttleRoute }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm<{ status: ShuttleRouteStatus }>({
+    defaultValues: {
+      status: shuttleRoute.status,
+    },
+  });
+
+  const status = useWatch({ control, name: 'status' });
+
+  const isAdvancedFrom = useMemo(() => {
+    return (
+      shuttleRoute.status === 'CANCELLED' || shuttleRoute.status === 'ENDED'
+    );
+  }, [shuttleRoute]);
+
+  const isAdvancedTo = useMemo(() => {
+    return status === 'CANCELLED';
+  }, [status]);
+
+  const options = useMemo(() => {
+    if (shuttleRoute.status === 'CANCELLED' || shuttleRoute.status === 'ENDED')
+      return [];
+    return ShuttleRouteStatusEnum.options.filter(
+      (s) => s !== 'INACTIVE' && s !== 'ENDED',
+    );
+  }, [shuttleRoute.status]);
+
+  const { mutate: putShuttleRoute } = usePutShuttleRoute({
+    onSuccess: () => {
+      alert('노선 상태가 수정되었습니다.');
+      setIsOpen(false);
+    },
+    onError: (error) => {
+      alert(`노선 상태 수정에 실패했습니다.\n${error}`);
+    },
+  });
+
+  const onSubmit = async (data: { status: ShuttleRouteStatus }) => {
+    if (!confirm('노선 상태를 수정하시겠습니까?')) return;
+    putShuttleRoute({
+      eventId: shuttleRoute.eventId,
+      dailyEventId: shuttleRoute.dailyEventId,
+      shuttleRouteId: shuttleRoute.shuttleRouteId,
+      body: data,
+    });
+  };
+
+  return (
+    <>
+      <BlueButton onClick={() => setIsOpen(true)}>노선 상태 수정</BlueButton>
+      <Dialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        transition
+        className="fixed inset-0 flex w-screen items-center justify-center bg-black/30 p-4 transition duration-75 ease-out data-[closed]:opacity-0"
+      >
+        <DialogPanel className="max-w-lg space-y-8 rounded-xl bg-white p-24">
+          <DialogTitle className="text-26 font-700">노선 상태 수정</DialogTitle>
+          <Description>노선 상태를 수정합니다.</Description>
+          <form className="space-y-8" onSubmit={handleSubmit(onSubmit)}>
+            <div className="flex w-256 flex-row items-center justify-between rounded-lg border border-grey-100 bg-white p-8">
+              {Stringifier.shuttleRouteStatus(shuttleRoute.status)}
+            </div>
+            {isAdvancedFrom && (
+              <p className="text-12 font-600 text-red-500">
+                더이상 상태를 변경할 수 없습니다.
+              </p>
+            )}
+            <ArrowDownIcon />
+            <Controller
+              control={control}
+              name={`status`}
+              render={({ field: { onChange, value } }) => (
+                <>
+                  <List
+                    value={value}
+                    setValue={onChange}
+                    toLabel={Stringifier.shuttleRouteStatus}
+                    toId={(v) => v}
+                    values={options}
+                    disabled={
+                      shuttleRoute.status === 'CANCELLED' ||
+                      shuttleRoute.status === 'ENDED'
+                    }
+                  />
+                  {isAdvancedTo && (
+                    <p className="text-12 font-600 text-red-500">
+                      <MessageSquareWarningIcon className="inline" /> 주의: 이
+                      행위는 되돌릴 수 없습니다.
+                      <br />
+                      해당 노선 예약자 모두 예약 취소 및 환불 처리됩니다.
+                    </p>
+                  )}
+                </>
+              )}
+            />
+            <div className="flex justify-end gap-4 text-white [&>button]:rounded-lg [&>button]:px-16 [&>button]:py-4">
+              <button
+                type="button"
+                className="bg-grey-400 transition-all hover:scale-95 active:scale-90"
+                onClick={() => setIsOpen(false)}
+              >
+                이 창 닫기
+              </button>
+              <button
+                className={`bg-blue-400 transition-all ${
+                  isSubmitting ? '' : 'hover:scale-95 active:scale-90'
+                } disabled:cursor-not-allowed disabled:opacity-50`}
+                disabled={
+                  shuttleRoute.status === 'CANCELLED' ||
+                  shuttleRoute.status === 'ENDED' ||
+                  isSubmitting
+                }
+              >
+                수정
+              </button>
+            </div>
+          </form>
+        </DialogPanel>
+      </Dialog>
+    </>
+  );
+};
+
+export default EditRouteStatusDialog;
+
+interface ListProps<T> {
+  value: T;
+  values: readonly T[];
+  setValue: (t: T) => void;
+  toLabel: (t: T) => string;
+  toId: (t: T) => string;
+  disabled?: boolean;
+}
+
+const List = <T,>({
+  value,
+  values,
+  setValue,
+  toLabel,
+  toId,
+  disabled,
+}: ListProps<T>) => {
+  return (
+    <Listbox value={value} onChange={setValue} disabled={disabled}>
+      <ListboxButton
+        className="flex w-256 flex-row items-center justify-between rounded-lg border border-grey-100 bg-white p-8 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+      >
+        {toLabel(value)}
+        <ChevronDownIcon />
+      </ListboxButton>
+      <ListboxOptions
+        className="w-[var(--button-width)] origin-top rounded-lg border border-grey-100 bg-white"
+        anchor="bottom"
+      >
+        {values.map((v) => (
+          <ListboxOption
+            key={toId(v)}
+            value={v}
+            className="p-8 data-[focus]:bg-blue-100"
+          >
+            {toLabel(v)}
+          </ListboxOption>
+        ))}
+      </ListboxOptions>
+    </Listbox>
+  );
+};

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/form.type.ts
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/form.type.ts
@@ -1,3 +1,4 @@
+import { ShuttleRouteStatusEnum } from '@/types/shuttleRoute.type';
 import { z } from 'zod';
 
 export const EditFormValuesSchema = z.object({
@@ -6,6 +7,7 @@ export const EditFormValuesSchema = z.object({
   hasEarlybird: z.boolean(),
   earlybirdDeadline: z.string().optional(),
   maxPassengerCount: z.number().int(),
+  status: ShuttleRouteStatusEnum,
   shuttleRouteHubsFromDestination: z.array(
     z.object({
       shuttleRouteHubId: z.string().optional(),

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
@@ -31,6 +31,7 @@ const Page = ({ params }: Props) => {
     () => ({
       name: route?.name ?? '',
       hasEarlybird: route?.hasEarlybird ?? false,
+      status: route?.status ?? 'INACTIVE',
       earlybirdDeadline: route?.earlybirdDeadline ?? '',
       earlybirdPrice: route?.hasEarlybird
         ? {

--- a/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
@@ -9,6 +9,7 @@ import {
   removeShuttleRouteDemand,
   setShuttleRouteDemand,
 } from './routeDemand.util';
+import EditRouteStatusDialog from './EditRouteStatusDialog';
 
 const columnHelper = createColumnHelper<AdminShuttleRoutesViewEntity>();
 
@@ -131,6 +132,13 @@ export const columns = [
       >
         노선 상세보기
       </BlueLink>
+    ),
+  }),
+  columnHelper.display({
+    id: 'statusAction',
+    header: () => '노선 상태 변경',
+    cell: (props) => (
+      <EditRouteStatusDialog shuttleRoute={props.row.original} />
     ),
   }),
 ];

--- a/src/services/shuttleRoute.service.ts
+++ b/src/services/shuttleRoute.service.ts
@@ -137,6 +137,7 @@ interface PutShuttleRouteBody {
   name?: string;
   reservationDeadline?: string;
   maxPassengerCount?: number;
+  status?: ShuttleRouteStatus;
   shuttleRouteHubs?: {
     shuttleRouteHubId?: string;
     regionHubId?: string;


### PR DESCRIPTION
## 개요
행사 탭 - 노선 보기 - 노선 상태 변경 기능이 추가되었습니다.

## 변경사항
- 노선의 상태를 변경할 수 있습니다.
  - `OPEN` <-> `CLOSED`
  - `OPEN` -> `CANCELLED`
  - `CLOSED` -> `CANCELLED`
  - `CANCELLED` or `ENDED` 에서는 상태변경 불가능
- invalidQuery 로 노선의 데이터를 갱신하는 방법으로는 상태를 바로 갱신할 수 없었습니다. 
  - 이전에 듣기로 백엔드 구조상 업데이트되면 바로 데이터가 갱신되지 않는다고 알고 있는데요. 그래서 invalidateQueries로 노선의 데이터가 즉시 갱신되지 않는 듯 합니다.
  - window.location.reload()로 브라우저 페이지를 강제 새로고침하도록 해두었습니다.

### OPEN <-> CLOSED
https://github.com/user-attachments/assets/b643dbc6-f8df-4cc7-a478-50c548a64f47

### 무산

https://github.com/user-attachments/assets/43c81db6-996f-44a7-a3b2-81c82efce5d7


![IMG_7716](https://github.com/user-attachments/assets/70e0b0bc-3964-40cb-a802-39842fc81e71)

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).