### PR TITLE
design: 수요조사 대시보드에 관련 행사 정보 표기 (Suspense 적용)

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/page.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import Heading from '@/components/text/Heading';
+import Callout from '@/components/text/Callout';
+import List from '@/components/text/List';
+import BlueLink from '@/components/link/BlueLink';
 import Map from './components/Map';
 import { useState } from 'react';
 import Table from './components/Table';
+import { formatDateString } from '@/utils/date.util';
+import { useGetEvent } from '@/services/event.service';
+import { notFound } from 'next/navigation';
 
 type Tab = 'map' | 'table';
 interface Props {
@@ -15,9 +21,14 @@ interface Props {
 
 const Page = ({ params }: Props) => {
   const { eventId, dailyEventId } = params;
+  const { data: event, isLoading: isEventLoading } = useGetEvent(eventId);
 
   const [tab, setTab] = useState<Tab>('map');
 
+  if (isEventLoading) {
+    return <div>Loading...</div>;
+  }
+  if (!event) return notFound();
   return (
     <main className="flex grow flex-col">
       <Heading className="flex items-baseline gap-12">
@@ -41,6 +52,20 @@ const Page = ({ params }: Props) => {
           </button>
         </div>
       </Heading>
+      <Callout className="mb-16">
+        <List>
+          <List.item title="행사명">
+            <BlueLink href={`/events/${eventId}`}>{event.eventName}</BlueLink>
+          </List.item>
+          <List.item title="날짜">
+            {formatDateString(
+              event.dailyEvents.find(
+                (dailyEvent) => dailyEvent.dailyEventId === dailyEventId,
+              )?.date,
+            )}
+          </List.item>
+        </List>
+      </Callout>
       <div className="flex grow gap-12">
         {tab === 'map' && <Map eventId={eventId} dailyEventId={dailyEventId} />}
         {tab === 'table' && (

--- a/src/app/events/[eventId]/dates/[dailyEventId]/demands/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/demands/page.tsx
@@ -5,30 +5,33 @@ import Callout from '@/components/text/Callout';
 import List from '@/components/text/List';
 import BlueLink from '@/components/link/BlueLink';
 import Map from './components/Map';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import Table from './components/Table';
 import { formatDateString } from '@/utils/date.util';
-import { useGetEvent } from '@/services/event.service';
-import { notFound } from 'next/navigation';
+import { useSuspenseGetEvent } from '@/services/event.service';
+import Loading from '@/components/loading/Loading';
+import { useParams } from 'next/navigation';
 
 type Tab = 'map' | 'table';
-interface Props {
-  params: {
+
+const Page = () => {
+  return (
+    <Suspense fallback={<Loading />}>
+      <DemandContent />
+    </Suspense>
+  );
+};
+
+export default Page;
+
+const DemandContent = () => {
+  const { eventId, dailyEventId } = useParams<{
     eventId: string;
     dailyEventId: string;
-  };
-}
-
-const Page = ({ params }: Props) => {
-  const { eventId, dailyEventId } = params;
-  const { data: event, isLoading: isEventLoading } = useGetEvent(eventId);
-
+  }>();
   const [tab, setTab] = useState<Tab>('map');
+  const { data: event } = useSuspenseGetEvent(eventId);
 
-  if (isEventLoading) {
-    return <div>Loading...</div>;
-  }
-  if (!event) return notFound();
   return (
     <main className="flex grow flex-col">
       <Heading className="flex items-baseline gap-12">
@@ -75,5 +78,3 @@ const Page = ({ params }: Props) => {
     </main>
   );
 };
-
-export default Page;

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -25,6 +25,7 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  useSuspenseQuery,
 } from '@tanstack/react-query';
 import { silentParse } from '@/utils/parse.util';
 
@@ -64,6 +65,13 @@ export const getEvent = async (eventId: string) => {
 
 export const useGetEvent = (eventId: string) => {
   return useQuery({
+    queryKey: ['event', eventId],
+    queryFn: () => getEvent(eventId),
+  });
+};
+
+export const useSuspenseGetEvent = (eventId: string) => {
+  return useSuspenseQuery({
     queryKey: ['event', eventId],
     queryFn: () => getEvent(eventId),
   });


### PR DESCRIPTION
## 개요
수요조사 페이지를 들어올때마다 어떤 행사의 수요조사인지 기재가 되었으면 좋겠다는 건의사항에 따라 편의기능을 개발하였습니다.

## 변경사항
- 행사명과 해당하는 일일행사 날짜를 함께 보여줍니다.
- react 의 suspense를 적용하였습니다. 선언적으로 코드를 작성할 수 있습니다. suspense와 함께 동작하기위해서 useQuery 대신 useSuspenseQuery를 사용하였습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).