### PR TITLE
feat: 노선 생성 및 수정 시 일자별 행사 정보 표시

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/page.tsx
@@ -20,10 +20,10 @@ interface Props {
 
 const Page = ({ params: { eventId, dailyEventId } }: Props) => {
   const {
-    data: shuttle,
-    isPending: isShuttlePending,
-    isError: isShuttleError,
-    error: shuttleError,
+    data: event,
+    isPending: isEventPending,
+    isError: isEventError,
+    error: eventError,
   } = useGetEvent(eventId);
 
   const {
@@ -35,46 +35,44 @@ const Page = ({ params: { eventId, dailyEventId } }: Props) => {
 
   const table = useTable({ data: routes, columns });
 
-  const thisDailyShuttle = shuttle
-    ? shuttle.dailyEvents.find((d) => d.dailyEventId === dailyEventId)
+  const dailyEvent = event
+    ? event.dailyEvents.find((d) => d.dailyEventId === dailyEventId)
     : null;
 
   useEffect(() => {
-    if (shuttle && !thisDailyShuttle) {
+    if (event && !dailyEvent) {
       notFound();
     }
-  }, [shuttle, thisDailyShuttle]);
+  }, [event, dailyEvent]);
 
-  if (isShuttleError || isRoutesError) {
+  if (isEventError || isRoutesError) {
     return (
       <div>
-        Error! shuttle error : {shuttleError?.message}, or routes error :{' '}
+        Error! event error : {eventError?.message}, or routes error :{' '}
         {routesError?.message}
       </div>
     );
   }
 
-  if (isShuttlePending || isRoutesPending) {
+  if (isEventPending || isRoutesPending) {
     return <div>Loading...</div>;
   }
 
   return (
     <main>
       <Heading>일자별 행사 상세 정보</Heading>
-      {thisDailyShuttle && (
+      {dailyEvent && (
         <Callout>
           <List>
             <List.item title="행사명">
-              <BlueLink href={`/events/${eventId}`}>
-                {shuttle.eventName}
-              </BlueLink>
+              <BlueLink href={`/events/${eventId}`}>{event.eventName}</BlueLink>
             </List.item>
-            <List.item title="장소">{shuttle.eventLocationName}</List.item>
+            <List.item title="장소">{event.eventLocationName}</List.item>
             <List.item title="날짜">
-              {formatDateString(thisDailyShuttle.date)}
+              {formatDateString(dailyEvent.date)}
             </List.item>
             <List.item title="상태">
-              {Stringifier.dailyEventStatus(thisDailyShuttle?.status)}
+              {Stringifier.dailyEventStatus(dailyEvent?.status)}
             </List.item>
           </List>
         </Callout>

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/edit/page.tsx
@@ -6,6 +6,11 @@ import Heading from '@/components/text/Heading';
 import EditForm from './components/EditForm';
 import { extractSortedShuttleHubs } from './utils/extractSortedShuttleHubs.util';
 import { EditFormValues } from './form.type';
+import Callout from '@/components/text/Callout';
+import List from '@/components/text/List';
+import BlueLink from '@/components/link/BlueLink';
+import { formatDateString } from '@/utils/date.util';
+import Stringifier from '@/utils/stringifier.util';
 
 interface Props {
   params: { eventId: string; dailyEventId: string; shuttleRouteId: string };
@@ -20,6 +25,10 @@ const Page = ({ params }: Props) => {
     isError: isRouteError,
     error: routeError,
   } = useGetShuttleRoute(eventId, dailyEventId, shuttleRouteId);
+
+  const dailyEvent = route?.event?.dailyEvents.find(
+    (de) => de.dailyEventId === dailyEventId,
+  );
 
   const defaultDate = useMemo(() => {
     return route?.event.dailyEvents.find(
@@ -64,6 +73,24 @@ const Page = ({ params }: Props) => {
   return (
     <main>
       <Heading>노선 수정하기</Heading>
+      {route && dailyEvent && (
+        <Callout className="mb-20">
+          <List>
+            <List.item title="행사명">
+              <BlueLink href={`/events/${eventId}`}>
+                {route.event.eventName}
+              </BlueLink>
+            </List.item>
+            <List.item title="장소">{route.event.eventLocationName}</List.item>
+            <List.item title="날짜">
+              {formatDateString(dailyEvent.date)}
+            </List.item>
+            <List.item title="상태">
+              {Stringifier.dailyEventStatus(dailyEvent.status)}
+            </List.item>
+          </List>
+        </Callout>
+      )}
       <EditForm
         params={params}
         defaultValues={defaultValues}

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/table.type.tsx
@@ -77,6 +77,13 @@ export const shuttleRouteColumns = [
       return value ? formatDateString(value, 'datetime') : '-';
     },
   }),
+  shuttleRouteColumnHelper.accessor('earlybirdPriceRoundTrip', {
+    header: () => '얼리버드 왕복 가격',
+    cell: (info) => {
+      const value = info.getValue();
+      return value ? value.toLocaleString() : '-';
+    },
+  }),
   shuttleRouteColumnHelper.accessor('earlybirdPriceToDestination', {
     header: () => '얼리버드 가는 편 가격',
     cell: (info) => {

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -25,6 +25,10 @@ import { RouteHubData } from '../utils/calculateRoute';
 import { extractHubs } from './utils/extractHubs';
 import { transformToShuttleRouteRequest } from './utils/transformToShuttleRouteRequest';
 import { validateShuttleRouteData } from './utils/validateShuttleRouteData';
+import Stringifier from '@/utils/stringifier.util';
+import List from '@/components/text/List';
+import BlueLink from '@/components/link/BlueLink';
+import { formatDateString } from '@/utils/date.util';
 
 interface Props {
   params: { eventId: string; dailyEventId: string };
@@ -34,6 +38,10 @@ const Page = ({ params }: Props) => {
   const { eventId, dailyEventId } = params;
 
   const { data: event, isPending, isError, error } = useGetEvent(eventId);
+
+  const dailyEvent = event
+    ? event.dailyEvents.find((d) => d.dailyEventId === dailyEventId)
+    : null;
 
   const defaultDate = useMemo(() => {
     return event?.dailyEvents.find((de) => de.dailyEventId === dailyEventId)
@@ -97,12 +105,31 @@ const Page = ({ params }: Props) => {
   if (isError) return <div>Error! {error?.message}</div>;
 
   return (
-    <Form
-      event={event}
-      params={params}
-      defaultValues={defaultValues}
-      defaultDate={defaultDate ?? ''}
-    />
+    <main>
+      <Heading>노선 추가하기</Heading>
+      {dailyEvent && (
+        <Callout className="mb-20">
+          <List>
+            <List.item title="행사명">
+              <BlueLink href={`/events/${eventId}`}>{event.eventName}</BlueLink>
+            </List.item>
+            <List.item title="장소">{event.eventLocationName}</List.item>
+            <List.item title="날짜">
+              {formatDateString(dailyEvent.date)}
+            </List.item>
+            <List.item title="상태">
+              {Stringifier.dailyEventStatus(dailyEvent.status)}
+            </List.item>
+          </List>
+        </Callout>
+      )}
+      <Form
+        event={event}
+        params={params}
+        defaultValues={defaultValues}
+        defaultDate={defaultDate ?? ''}
+      />
+    </main>
   );
 };
 
@@ -250,7 +277,6 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
 
   return (
     <main>
-      <Heading>노선 추가하기</Heading>
       <FormContainer onSubmit={handleSubmit(onSubmit)}>
         <FormContainer.section>
           <FormContainer.label htmlFor="name" required>

--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/new/page.tsx
@@ -187,7 +187,7 @@ const Form = ({ params, defaultValues, defaultDate }: FormProps) => {
   const onSubmit = async (data: CreateFormValues) => {
     if (
       !confirm(
-        '추가하시겠습니까? 확인을 누르시면 가격은 더 이상 변경할 수 없습니다. ',
+        '추가하시겠습니까? 노선 생성 후 가격 변동은 최대한 자제해주세요. ',
       )
     ) {
       return;


### PR DESCRIPTION
## 개요

노선 생성 및 수정 시 상단에 해당하는 일자별 행사의 정보가 띄워지도록 수정했습니다.

또한 기존에 노선 상세 페이지에서 얼리버드 왕복 가격 항목이 없던 부분을 추가했습니다.

## 변경사항

<img width="1340" alt="스크린샷 2025-06-27 오전 11 27 03" src="https://github.com/user-attachments/assets/1194789f-2785-4afd-acec-c9b867d93e8f" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).