### PR TITLE
feat: 유요한 예약수에 인원수를 함께 표기

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/reservations/components/ReservationTable.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/routes/[shuttleRouteId]/reservations/components/ReservationTable.tsx
@@ -55,6 +55,12 @@ const ReservationTable = ({ eventId, dailyEventId, shuttleRouteId }: Props) => {
     data: filteredReservations,
   });
 
+  const totalNumberOfPeople = useMemo(() => {
+    return validReservations.reduce((acc, reservation) => {
+      return acc + reservation.passengerCount;
+    }, 0);
+  }, [validReservations]);
+
   const { mutate: putReservation } = usePutReservation();
 
   const rejectAllSupportedHandy = async () => {
@@ -95,8 +101,8 @@ const ReservationTable = ({ eventId, dailyEventId, shuttleRouteId }: Props) => {
       <Heading.h2 className="flex items-center gap-12">
         배차되지 않은 예약{' '}
         <span className="text-14 font-400 text-grey-700">
-          유효한 예약 {validReservations.length}건 / 합계 {reservations.length}
-          건
+          유효한 예약 {validReservations.length}건 ({totalNumberOfPeople}인) /
+          합계 {reservations.length}건
         </span>
         <Toggle
           label="취소된 예약 포함"


### PR DESCRIPTION
## 개요
행사 - 노선보기 - 예약상세에서 유효한 예약에 총인원수를 함께 표기합니다

| 유효한 예약 12건 (18인) / 합계 12건 [배차되지 않은 예약 인원 경우] | 유효한 예약 0건 (0인) / 합계 5건 [모두 배차된 예약 인원 경우] |
|--------|--------|
| <img width="880" alt="Screenshot 2025-06-27 at 2 39 49 PM" src="https://github.com/user-attachments/assets/3cde3604-d428-4d62-b190-408726c5db13" /> | <img width="877" alt="Screenshot 2025-06-27 at 2 39 42 PM" src="https://github.com/user-attachments/assets/8aa9090f-ce42-4058-bcfe-96fb4be79f98" /> | 


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).