### PR TITLE
feat: 알림톡 발송하기

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/page.tsx
@@ -8,7 +8,10 @@ import { columns } from './table.type';
 import { useEffect, useMemo } from 'react';
 import { formatDateString } from '@/utils/date.util';
 import Stringifier from '@/utils/stringifier.util';
-import { useGetShuttleRoutesOfDailyEvent } from '@/services/shuttleRoute.service';
+import {
+  useGetShuttleRoutesOfDailyEvent,
+  useSendShuttleInformation,
+} from '@/services/shuttleRoute.service';
 import { useGetEvent } from '@/services/event.service';
 import Heading from '@/components/text/Heading';
 import Callout from '@/components/text/Callout';
@@ -34,6 +37,11 @@ const Page = ({ params: { eventId, dailyEventId } }: Props) => {
     isError: isRoutesError,
     error: routesError,
   } = useGetShuttleRoutesOfDailyEvent(eventId, dailyEventId);
+
+  const {
+    mutateAsync: sendShuttleInformation,
+    isPending: isSendShuttleInformationPending,
+  } = useSendShuttleInformation();
 
   const sortedRoutes = useMemo(() => {
     if (!routes) {
@@ -71,6 +79,34 @@ const Page = ({ params: { eventId, dailyEventId } }: Props) => {
   const dailyEvent = event
     ? event.dailyEvents.find((d) => d.dailyEventId === dailyEventId)
     : null;
+
+  const handleSendShuttleInformationAllDailyEventRoutes = async () => {
+    const isConfirmed = confirm(
+      '일자별 노선 전체에 대해 알림톡을 발송하시겠습니까?',
+    );
+    if (!isConfirmed) {
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      routes.map((route) =>
+        sendShuttleInformation({
+          eventId,
+          dailyEventId,
+          shuttleRouteId: route.shuttleRouteId,
+        }),
+      ),
+    );
+    const successCount = results.filter(
+      (result) => result.status === 'fulfilled',
+    ).length;
+    const failedCount = results.filter(
+      (result) => result.status === 'rejected',
+    ).length;
+    alert(
+      `알림톡 발송 완료 (${successCount} / ${routes.length}) ${failedCount ? `\n 실패한 노선 : ${failedCount}` : ''}`,
+    );
+  };
 
   useEffect(() => {
     if (event && !dailyEvent) {
@@ -116,25 +152,35 @@ const Page = ({ params: { eventId, dailyEventId } }: Props) => {
           <BlueLink href={`${dailyEventId}/routes/new`} className="text-14">
             추가하기
           </BlueLink>
+          <button
+            className="text-14 text-blue-500 underline underline-offset-[3px]"
+            onClick={handleSendShuttleInformationAllDailyEventRoutes}
+            disabled={isSendShuttleInformationPending}
+          >
+            알림톡 발송하기 (일자별 노선 전체)
+          </button>
+        </Heading.h2>
+        <div className="mb-12 flex justify-start gap-20 bg-notion-grey px-20 py-12">
+          <h5 className="whitespace-nowrap text-14">핸디팟 기능 :</h5>
           <BlueLink
             href={`${dailyEventId}/handy-party/optimizer-paste`}
             className="text-14"
           >
-            핸디팟 최적 경로 계산기 (엑셀 복붙하기)
+            핸디팟 경로 계산 (엑셀 복붙)
           </BlueLink>
           <BlueLink
             href={`${dailyEventId}/handy-party/optimizer`}
             className="text-14"
           >
-            일자별 행사 핸디팟 최적 경로 계산기 (엑셀 추출하기)
+            일자별 행사 핸디팟 경로 계산 (엑셀 추출)
           </BlueLink>
           <BlueLink
             href={`${dailyEventId}/handy-party/vehicle-auto-assignment`}
             className="text-14"
           >
-            일자별 행사 핸디팟 자동 배차하기
+            일자별 행사 핸디팟 자동 배차
           </BlueLink>
-        </Heading.h2>
+        </div>
         <BaseTable table={table} />
       </div>
     </main>

--- a/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
@@ -5,6 +5,8 @@ import BlueLink from '@/components/link/BlueLink';
 import { AdminShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 import Stringifier from '@/utils/stringifier.util';
 import EditRouteStatusDialog from './EditRouteStatusDialog';
+import BlueButton from '@/components/link/BlueButton';
+import { sendShuttleInformation } from '@/services/shuttleRoute.service';
 
 const columnHelper = createColumnHelper<AdminShuttleRoutesViewEntity>();
 
@@ -80,18 +82,49 @@ export const columns = [
     id: 'route-detail',
     header: () => '노선 상세',
     cell: (props) => (
-      <BlueLink
-        href={`/events/${props.row.original.eventId}/dates/${props.row.original.dailyEventId}/routes/${props.row.original.shuttleRouteId}`}
-      >
-        노선 상세보기
-      </BlueLink>
+      <div className="flex flex-col items-center">
+        <BlueLink
+          href={`/events/${props.row.original.eventId}/dates/${props.row.original.dailyEventId}/routes/${props.row.original.shuttleRouteId}`}
+        >
+          노선 상세보기
+        </BlueLink>
+        <BlueLink
+          href={`/events/${props.row.original.eventId}/dates/${props.row.original.dailyEventId}/routes/${props.row.original.shuttleRouteId}/edit`}
+        >
+          노선 수정하기
+        </BlueLink>
+        <EditRouteStatusDialog shuttleRoute={props.row.original} />
+      </div>
     ),
   }),
   columnHelper.display({
     id: 'statusAction',
     header: () => '노선 상태 변경',
     cell: (props) => (
-      <EditRouteStatusDialog shuttleRoute={props.row.original} />
+      <BlueButton
+        onClick={async () => {
+          try {
+            const isConfirmed = confirm(
+              `${props.row.original.name} 노선에 대해 알림톡을 발송하시겠습니까?`,
+            );
+            if (!isConfirmed) {
+              return;
+            }
+
+            await sendShuttleInformation(
+              props.row.original.eventId,
+              props.row.original.dailyEventId,
+              props.row.original.shuttleRouteId,
+            );
+            alert('알림톡 발송 완료');
+          } catch (error) {
+            console.error(error);
+            alert('알림톡 발송 실패');
+          }
+        }}
+      >
+        알림톡 발송하기
+      </BlueButton>
     ),
   }),
 ];

--- a/src/services/shuttleRoute.service.ts
+++ b/src/services/shuttleRoute.service.ts
@@ -244,3 +244,27 @@ export const useDeleteShuttleRoutes = () => {
     }) => deleteShuttleRoutes(eventId, dailyEventId, body),
   });
 };
+
+export const sendShuttleInformation = async (
+  eventId: string,
+  dailyEventId: string,
+  shuttleRouteId: string,
+) => {
+  await authInstance.post(
+    `/v1/shuttle-operation/admin/events/${eventId}/dates/${dailyEventId}/routes/${shuttleRouteId}/send-shuttle-information`,
+  );
+};
+
+export const useSendShuttleInformation = () => {
+  return useMutation({
+    mutationFn: ({
+      eventId,
+      dailyEventId,
+      shuttleRouteId,
+    }: {
+      eventId: string;
+      dailyEventId: string;
+      shuttleRouteId: string;
+    }) => sendShuttleInformation(eventId, dailyEventId, shuttleRouteId),
+  });
+};


### PR DESCRIPTION
## 개요
- 일자별 모든 노선에 알림톡 보내기, 각 노선마다 알림톡 보내기 기능을 추가하였습니다.
- 요청사항에 따라 노선 수정하기를 노선 목록에도 추가하였습니다.

현재 api 요청 및 응답은 성공하지만, 실제 솔라피가 발송이 안되고 있습니다. 확인예정
## 변경사항
#### 일자별 모든 노선에 알림톡 보내기

https://github.com/user-attachments/assets/859ee85f-e37a-4cc1-b56b-90ee4b08f40a

 #### 각 노선에 알림톡 보내기


https://github.com/user-attachments/assets/c78680f2-9b23-4f63-98eb-d370d3fbdcd2

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).