### PR TITLE
feat: 노선 개설 관련 알림톡 발송 기능

### DIFF
--- a/src/app/events/[eventId]/dates/[dailyEventId]/page.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/page.tsx
@@ -10,7 +10,6 @@ import { formatDateString } from '@/utils/date.util';
 import Stringifier from '@/utils/stringifier.util';
 import {
   useGetShuttleRoutesOfDailyEvent,
-  useSendShuttleInformation,
   useGetAlertRequests,
 } from '@/services/shuttleRoute.service';
 import { useGetEvent } from '@/services/event.service';
@@ -20,6 +19,7 @@ import List from '@/components/text/List';
 import { HANDY_PARTY_PREFIX } from '@/constants/common';
 import { HANDY_PARTY_ROUTE_AREA } from '@/constants/handyPartyArea.const';
 import EditDailyEventOpenChatUrl from './EditDailyEventOpenChatUrl';
+import { useSendShuttleInformation } from '@/services/solapi.service';
 
 interface Props {
   params: { eventId: string; dailyEventId: string };

--- a/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
+++ b/src/app/events/[eventId]/dates/[dailyEventId]/table.type.tsx
@@ -6,7 +6,7 @@ import { AdminShuttleRoutesViewEntity } from '@/types/shuttleRoute.type';
 import Stringifier from '@/utils/stringifier.util';
 import EditRouteStatusDialog from './EditRouteStatusDialog';
 import BlueButton from '@/components/link/BlueButton';
-import { sendShuttleInformation } from '@/services/shuttleRoute.service';
+import { sendShuttleInformation } from '@/services/solapi.service';
 import { HANDY_PARTY_PREFIX } from '@/constants/common';
 
 const columnHelper = createColumnHelper<AdminShuttleRoutesViewEntity>();

--- a/src/app/events/[eventId]/table.type.tsx
+++ b/src/app/events/[eventId]/table.type.tsx
@@ -6,10 +6,63 @@ import { formatDateString } from '@/utils/date.util';
 import { EventsViewEntity } from '@/types/event.type';
 import { DEFAULT_EVENT_IMAGE } from '@/constants/common';
 import BlueLink from '@/components/link/BlueLink';
+import BlueButton from '@/components/link/BlueButton';
+import {
+  sendDemandedShuttleRouteDoneCreating,
+  sendDemandedShuttleRouteNotCreated,
+} from '@/services/solapi.service';
 
 const columnHelper = createColumnHelper<EventsViewEntity>();
 
 export const columns = [
+  columnHelper.display({
+    id: 'action',
+    header: '액션',
+    cell: (props) => {
+      const { eventId } = props.row.original;
+
+      const handleSendShuttleRouteNotCreated = async () => {
+        const isConfirmed = window.confirm(
+          '노선 미개설 안내를 발송하시겠습니까?\n* 안내를 기존에 발송했는지 확인해주세요.\n* 수요조사에 참여한 모든 유저들에게 발송됩니다.',
+        );
+        if (!isConfirmed) {
+          return;
+        }
+        try {
+          await sendDemandedShuttleRouteNotCreated(eventId);
+        } catch (error) {
+          console.error(error);
+          window.alert('발송에 실패했습니다.');
+        }
+      };
+
+      const handleSendShuttleRouteDoneCreating = async () => {
+        const isConfirmed = window.confirm(
+          '노선 최종 개설 안내를 발송하시겠습니까?\n*안내를 기존에 발송했는지 확인해주세요.\n*수요조사에 참여하고 예약을 하지 않은 모든 유저들에게 발송됩니다.',
+        );
+        if (!isConfirmed) {
+          return;
+        }
+        try {
+          await sendDemandedShuttleRouteDoneCreating(eventId);
+        } catch (error) {
+          console.error(error);
+          window.alert('발송에 실패했습니다.');
+        }
+      };
+
+      return (
+        <div className="flex flex-col gap-8">
+          <BlueButton onClick={handleSendShuttleRouteNotCreated}>
+            노선 미개설 안내 발송
+          </BlueButton>
+          <BlueButton onClick={handleSendShuttleRouteDoneCreating}>
+            노선 최종 개설 안내 발송
+          </BlueButton>
+        </div>
+      );
+    },
+  }),
   columnHelper.display({
     id: 'image',
     header: '포스터',

--- a/src/services/shuttleRoute.service.ts
+++ b/src/services/shuttleRoute.service.ts
@@ -272,27 +272,3 @@ export const useDeleteShuttleRoutes = () => {
     }) => deleteShuttleRoutes(eventId, dailyEventId, body),
   });
 };
-
-export const sendShuttleInformation = async (
-  eventId: string,
-  dailyEventId: string,
-  shuttleRouteId: string,
-) => {
-  await authInstance.post(
-    `/v1/shuttle-operation/admin/events/${eventId}/dates/${dailyEventId}/routes/${shuttleRouteId}/send-shuttle-information`,
-  );
-};
-
-export const useSendShuttleInformation = () => {
-  return useMutation({
-    mutationFn: ({
-      eventId,
-      dailyEventId,
-      shuttleRouteId,
-    }: {
-      eventId: string;
-      dailyEventId: string;
-      shuttleRouteId: string;
-    }) => sendShuttleInformation(eventId, dailyEventId, shuttleRouteId),
-  });
-};

--- a/src/services/solapi.service.ts
+++ b/src/services/solapi.service.ts
@@ -1,0 +1,52 @@
+import { useMutation } from '@tanstack/react-query';
+import { authInstance } from './config';
+
+export const sendShuttleInformation = async (
+  eventId: string,
+  dailyEventId: string,
+  shuttleRouteId: string,
+) => {
+  await authInstance.post(
+    `/v1/shuttle-operation/admin/events/${eventId}/dates/${dailyEventId}/routes/${shuttleRouteId}/send-shuttle-information`,
+  );
+};
+
+export const useSendShuttleInformation = () => {
+  return useMutation({
+    mutationFn: ({
+      eventId,
+      dailyEventId,
+      shuttleRouteId,
+    }: {
+      eventId: string;
+      dailyEventId: string;
+      shuttleRouteId: string;
+    }) => sendShuttleInformation(eventId, dailyEventId, shuttleRouteId),
+  });
+};
+
+export const sendDemandedShuttleRouteNotCreated = async (eventId: string) => {
+  await authInstance.post(
+    `/v1/shuttle-operation/admin/events/${eventId}/send-demanded-shuttle-route-not-created`,
+  );
+};
+
+export const useSendDemandedShuttleRouteNotCreated = () => {
+  return useMutation({
+    mutationFn: ({ eventId }: { eventId: string }) =>
+      sendDemandedShuttleRouteNotCreated(eventId),
+  });
+};
+
+export const sendDemandedShuttleRouteDoneCreating = async (eventId: string) => {
+  await authInstance.post(
+    `/v1/shuttle-operation/admin/events/${eventId}/send-demanded-shuttle-route-done-creating`,
+  );
+};
+
+export const useSendDemandedShuttleRouteDoneCreating = () => {
+  return useMutation({
+    mutationFn: ({ eventId }: { eventId: string }) =>
+      sendDemandedShuttleRouteDoneCreating(eventId),
+  });
+};


### PR DESCRIPTION
## 개요

아래 상황들에 대하여 알림톡을 발송하는 기능을 구현했습니다.

- 수요조사 후 노선 미개설 시, 수요조사 한 모든 유저들에게
- 수요조사 후 노선 최종 개설 시, 수요조사 하고 예약하지 않은 모든 유저들에게

## 변경사항

<img width="1878" height="472" alt="스크린샷 2025-08-22 오후 6 07 29" src="https://github.com/user-attachments/assets/1d7f4833-a616-47c2-9c3e-bcb55329dc50" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).