### PR TITLE
design: 매출 대시보드에 노선명 필드에 y scroll 가리기 및 텍스트 짤리는 이슈해결

### DIFF
--- a/src/app/events/[eventId]/sales/components/SalesRow.tsx
+++ b/src/app/events/[eventId]/sales/components/SalesRow.tsx
@@ -181,7 +181,7 @@ const SalesRow = ({
   };
 
   return (
-    <div className="grid h-36 w-full grid-cols-[repeat(14,1fr)] items-center border-b border-basic-grey-200">
+    <div className="grid h-36 w-full grid-cols-[1.5fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] items-center border-b border-basic-grey-200">
       <div className="flex h-full w-full items-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-left text-14 font-500">
         {/* 노선명 */}
         {shuttleRouteName}

--- a/src/app/events/[eventId]/sales/components/SalesRow.tsx
+++ b/src/app/events/[eventId]/sales/components/SalesRow.tsx
@@ -182,19 +182,19 @@ const SalesRow = ({
 
   return (
     <div className="grid h-36 w-full grid-cols-[repeat(14,1fr)] items-center border-b border-basic-grey-200">
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-left text-14 font-500">
         {/* 노선명 */}
         {shuttleRouteName}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 총 매출 */}
         {totalSales.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 실 매출 */}
         {totalSalesWithDiscount.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 차량 대금 */}
         {isTotalRow ? (
           <span className="text-14 font-500">
@@ -209,11 +209,11 @@ const SalesRow = ({
           />
         )}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 쿠폰비 */}
         {couponCost.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-16 font-500 text-basic-black">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-16 font-500 text-basic-black">
         {/* 운영비 */}
         {isTotalRow && (
           <input
@@ -224,7 +224,7 @@ const SalesRow = ({
           />
         )}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-16 font-500 text-basic-black">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-16 font-500 text-basic-black">
         {/* 마케팅비 */}
         {isTotalRow && (
           <input
@@ -235,19 +235,19 @@ const SalesRow = ({
           />
         )}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 총 이익 */}
         {totalProfit.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 이익률 */}
         {profitRate.toLocaleString()}%
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 탑승자 수*/}
         {routeWithSales.totalPassengerCount.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 차량 수 */}
         {isTotalRow ? (
           <span className="text-14 font-500">
@@ -262,15 +262,15 @@ const SalesRow = ({
           />
         )}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 총 예약 수 */}
         {totalReservationCount.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 취소된 예약 수 */}
         {canceledReservationCount.toLocaleString()}
       </div>
-      <div className="flex h-full w-full items-center justify-center overflow-x-auto whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
+      <div className="flex h-full w-full items-center justify-center overflow-x-auto overflow-y-hidden whitespace-nowrap break-keep border-r border-basic-grey-200 text-center text-14 font-500">
         {/* 취소율 */}
         {canceledReservationRate.toLocaleString()}%
       </div>

--- a/src/app/events/[eventId]/sales/components/SalesTable.tsx
+++ b/src/app/events/[eventId]/sales/components/SalesTable.tsx
@@ -136,7 +136,7 @@ const SalesTable = ({ event, shuttleRoutes }: Props) => {
             <div key={dailyEventWithRoutesWithSales.dailyEventId}>
               <Heading.h4>{date}</Heading.h4>
               <div className="overflow-hidden rounded-8 bg-basic-white shadow-[0_2px_8px_0_rgba(0,0,0,0.08)]">
-                <div className="grid h-[32px] grid-cols-[repeat(14,1fr)] items-center bg-basic-grey-200">
+                <div className="grid h-[32px] grid-cols-[1.5fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr] items-center bg-basic-grey-200">
                   <h4 className="flex h-full items-center justify-center whitespace-nowrap break-keep border-r border-basic-white text-center text-16 font-500 text-basic-black">
                     노선명
                   </h4>


### PR DESCRIPTION
## 개요

기존의 문제점
- 스크롤이 왼쪽으로 더이상 도달하지 못함 (왼쪽에 짤린 글자 존재)
- y scroll 이 생겨서 칸이 더 부족해보임

해결
- 스크롤 시작지점이 글자의 시작지점으로 표기되게 변경
- y scroll 가리기
<img width="348" height="424" alt="Screenshot 2025-08-25 at 12 06 57 PM" src="https://github.com/user-attachments/assets/e38b1c39-f22d-485d-a564-0e8aadc8aed0" />


https://github.com/user-attachments/assets/58964621-234a-4800-bd65-3fdfd34aa59e


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).