### PR TITLE
feat: 장소 추가/수정하기에 로드뷰 추가

### DIFF
--- a/src/app/locations/components/Roadview.tsx
+++ b/src/app/locations/components/Roadview.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  placeName: string;
+  latitude: number;
+  longitude: number;
+  isKakaoReady?: boolean;
+}
+
+const Roadview = ({ placeName, latitude, longitude, isKakaoReady }: Props) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const roadviewRef = useRef<kakao.maps.Roadview | null>(null);
+  const roadviewClientRef = useRef<kakao.maps.RoadviewClient | null>(null);
+  const isInitialized = useRef(false);
+  const [isAvailable, setIsAvailable] = useState(true);
+
+  const initializeRoadview = () => {
+    try {
+      if (!mapRef.current || !window.kakao?.maps) return;
+
+      const instance = new window.kakao.maps.Roadview(mapRef.current);
+      const client = new window.kakao.maps.RoadviewClient();
+      roadviewRef.current = instance;
+      roadviewClientRef.current = client;
+
+      const position = new window.kakao.maps.LatLng(latitude, longitude);
+      client.getNearestPanoId(position, 50, (panoId) => {
+        if (!panoId) {
+          setIsAvailable(false);
+          return;
+        }
+        instance.setPanoId(panoId, position);
+        setIsAvailable(true);
+      });
+    } catch (error) {
+      setIsAvailable(false);
+      console.error(error);
+    }
+  };
+
+  // Initialize after Kakao SDK is ready
+  useEffect(() => {
+    if (
+      !mapRef.current ||
+      isInitialized.current ||
+      !isKakaoReady ||
+      !window.kakao?.maps
+    )
+      return;
+    isInitialized.current = true;
+    initializeRoadview();
+  }, [isKakaoReady]);
+
+  // 핀의 위치를 조정하면 로드뷰의 위치도 조정
+  useEffect(() => {
+    if (
+      !isInitialized.current ||
+      !roadviewRef.current ||
+      !roadviewClientRef.current ||
+      !window.kakao?.maps
+    )
+      return;
+
+    const position = new window.kakao.maps.LatLng(latitude, longitude);
+    roadviewClientRef.current.getNearestPanoId(position, 50, (panoId) => {
+      if (!panoId) {
+        setIsAvailable(false);
+        return;
+      }
+      roadviewRef.current?.setPanoId(panoId, position);
+      setIsAvailable(true);
+    });
+  }, [latitude, longitude]);
+
+  return (
+    <div className="relative h-full w-full">
+      <div
+        ref={mapRef}
+        aria-label={placeName + ' 로드뷰'}
+        className="h-full w-full rounded-b-[12px]"
+      />
+      {!isAvailable && (
+        <div className="absolute inset-0 flex items-center justify-center bg-basic-grey-50 text-12 font-500 text-basic-grey-600">
+          로드뷰를 지원하지 않는 위치입니다.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Roadview;
+
+// kakaomap docs 로드뷰생성하기 : https://apis.map.kakao.com/web/sample/basicRoadview/

--- a/src/components/input/CoordInput.tsx
+++ b/src/components/input/CoordInput.tsx
@@ -7,6 +7,7 @@ import KakaoMapScript from '../script/KakaoMapScript';
 import { useGetRegionHubsWithoutPagination } from '@/services/hub.service';
 import { findRegionId, toAddress } from '@/utils/region.util';
 import { standardizeRegionName } from '@/utils/region.util';
+import Roadview from '@/app/locations/components/Roadview';
 
 const MAP_CONSTANTS = {
   INITIAL_ZOOM_LEVEL: 4,
@@ -39,6 +40,7 @@ const INITIAL_ZOOM_LEVEL = 4;
 
 const CoordInput = ({ coord, setCoord }: Props) => {
   const [mapInitialized, setMapInitialized] = useState(false);
+  const [isKakaoReady, setIsKakaoReady] = useState(false);
   const mapRef = useRef<HTMLDivElement>(null);
   const [hasRequestedSearch, setHasRequestedSearch] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
@@ -317,7 +319,12 @@ const CoordInput = ({ coord, setCoord }: Props) => {
   return (
     <>
       <KakaoMapScript
-        onReady={() => window.kakao.maps.load(initializeMap)}
+        onReady={() =>
+          window.kakao.maps.load(() => {
+            setIsKakaoReady(true);
+            initializeMap();
+          })
+        }
         libraries={['services']}
       />
       <article className="relative h-auto p-16 [&_div]:cursor-pointer">
@@ -375,6 +382,14 @@ const CoordInput = ({ coord, setCoord }: Props) => {
           좌표: {coord.latitude}, {coord.longitude}
           <br />
           주소: {coord.address}
+        </div>
+        <div className="h-320 rounded-[12px]">
+          <Roadview
+            placeName={coord.address}
+            latitude={coord.latitude}
+            longitude={coord.longitude}
+            isKakaoReady={isKakaoReady}
+          />
         </div>
       </article>
     </>


### PR DESCRIPTION
## 개요
장소 추가/수정하기 페이지에서 설정한 핀의 위치에 가장 가까운 위치의 로드뷰 미리보기를 제공합니다. (방향도 정해짐)
핀의 위치를 조정하면 로드뷰도 함께 조정됩니다.

<img width="777" height="1281" alt="Screenshot 2025-09-18 at 1 49 05 PM" src="https://github.com/user-attachments/assets/f48f0005-ab28-4c34-905b-4a6b4620cdde" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).